### PR TITLE
Add A2A server library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This repository is a monorepo containing multiple projects located primarily und
 - **_langgraph_storage** – in-memory storage backend and queue implementation for local LangGraph operations.
 - **_a2a-template-langgraph** – example implementation of an A2A protocol serving a LangGraph agent.
 - **_agent-workflow** – example implementation of a langgraph project using langgraph_api as a server
+- **aion-agent-api** – implementation of an A2A server wrapping a LangGraph project.
 
 ## Additional guidelines
 

--- a/libs/aion-agent-api/README.md
+++ b/libs/aion-agent-api/README.md
@@ -1,0 +1,6 @@
+# AION Agent API (A2A)
+
+Implementation of an A2A protocol server that wraps a LangGraph project.
+
+This package exposes a small `A2AServer` utility built on top of the
+Google `a2a-sdk` and Starlette.

--- a/libs/aion-agent-api/pyproject.toml
+++ b/libs/aion-agent-api/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "aion-agent-api"
+version = "0.1.0"
+description = "A2A server wrapper for LangGraph projects"
+authors = ["Terminal Research Team <support@terminal.exchange>"]
+readme = "README.md"
+packages = [{include = "aion_agent_api", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+a2a-sdk = {path = "../_a2a-python", develop = true}
+uvicorn = "^0.23.0"
+starlette = "^0.32.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/libs/aion-agent-api/src/aion_agent_api/__init__.py
+++ b/libs/aion-agent-api/src/aion_agent_api/__init__.py
@@ -1,0 +1,5 @@
+"""A2A server for LangGraph projects."""
+
+from .server import A2AServer
+
+__all__ = ["A2AServer"]

--- a/libs/aion-agent-api/src/aion_agent_api/server.py
+++ b/libs/aion-agent-api/src/aion_agent_api/server.py
@@ -1,0 +1,37 @@
+"""A minimal A2A server wrapping a LangGraph project."""
+
+from __future__ import annotations
+
+import uvicorn
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers.request_handler import RequestHandler
+from a2a.types import AgentCard
+from starlette.applications import Starlette
+
+
+class A2AServer:
+    """Simple wrapper exposing a LangGraph project via the A2A protocol."""
+
+    def __init__(self, agent_card: AgentCard, handler: RequestHandler) -> None:
+        """Create a server.
+
+        Args:
+            agent_card: Metadata describing the agent.
+            handler: Implementation of the A2A request handler.
+        """
+        self._agent_card = agent_card
+        self._handler = handler
+        self._app: Starlette | None = None
+
+    def build_app(self) -> Starlette:
+        """Build the underlying Starlette application."""
+        application = A2AStarletteApplication(
+            agent_card=self._agent_card, http_handler=self._handler
+        )
+        self._app = application.build()
+        return self._app
+
+    def run(self, host: str = "127.0.0.1", port: int = 8000) -> None:
+        """Run the server using ``uvicorn``."""
+        app = self._app or self.build_app()
+        uvicorn.run(app, host=host, port=port)

--- a/libs/aion-agent-api/tests/test_server.py
+++ b/libs/aion-agent-api/tests/test_server.py
@@ -1,0 +1,48 @@
+from aion_agent_api.server import A2AServer
+from a2a.types import AgentCard, AgentCapabilities
+from a2a.server.request_handlers.request_handler import RequestHandler
+from starlette.applications import Starlette
+import pytest
+
+
+class DummyHandler(RequestHandler):
+    async def on_get_task(self, params, context=None):
+        return None
+
+    async def on_cancel_task(self, params, context=None):
+        return None
+
+    async def on_message_send(self, params, context=None):
+        return None
+
+    async def on_message_send_stream(self, params, context=None):
+        if False:
+            yield
+
+    async def on_set_task_push_notification_config(self, params, context=None):
+        return params
+
+    async def on_get_task_push_notification_config(self, params, context=None):
+        return None
+
+    async def on_resubscribe_to_task(self, params, context=None):
+        if False:
+            yield
+
+
+def test_build_app() -> None:
+    card = AgentCard(
+        name="TestAgent",
+        description="desc",
+        version="0.1",
+        url="http://localhost",
+        skills=[],
+        capabilities=AgentCapabilities(),
+        authentication={"schemes": []},
+        defaultInputModes=["text/plain"],
+        defaultOutputModes=["application/json"],
+    )
+    handler = DummyHandler()
+    server = A2AServer(card, handler)
+    app = server.build_app()
+    assert isinstance(app, Starlette)


### PR DESCRIPTION
## Summary
- implement `aion-agent-api` library providing a minimal A2A server
- document the project in `AGENTS.md`
- include basic unit tests

## Testing
- `pytest -q libs/aion-agent-api/tests` *(fails: ModuleNotFoundError: No module named 'uvicorn')*
