### PR TITLE
Add aion-agent-cli package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository is a monorepo containing multiple projects located primarily und
 - **_a2a-template-langgraph** – example implementation of an A2A protocol serving a LangGraph agent.
 - **_agent-workflow** – example implementation of a langgraph project using langgraph_api as a server
 - **aion-agent-api** – implementation of an A2A server wrapping a LangGraph project.
+- **aion-agent-cli** – command line interface for the Aion Python SDK.
 
 ## Additional guidelines
 

--- a/libs/aion-agent-cli/README.md
+++ b/libs/aion-agent-cli/README.md
@@ -1,0 +1,5 @@
+# Aion Agent CLI
+
+Command-line interface for the Aion Python SDK.
+
+This project provides a minimal CLI for running the Aion Agent API server.

--- a/libs/aion-agent-cli/pyproject.toml
+++ b/libs/aion-agent-cli/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "aion-agent-cli"
+version = "0.1.0"
+description = "Command line interface for the Aion Python SDK"
+authors = ["Terminal Research Team <support@terminal.exchange>"]
+readme = "README.md"
+packages = [{include = "aion_agent_cli", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+click = "^8.1.8"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+aion = "aion_agent_cli.cli:cli"

--- a/libs/aion-agent-cli/src/aion_agent_cli/__init__.py
+++ b/libs/aion-agent-cli/src/aion_agent_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Aion Agent CLI package."""
+
+from aion_agent_cli.cli import cli
+
+__all__ = ["cli"]

--- a/libs/aion-agent-cli/src/aion_agent_cli/cli.py
+++ b/libs/aion-agent-cli/src/aion_agent_cli/cli.py
@@ -1,0 +1,51 @@
+"""Command-line interface for the Aion Python SDK."""
+
+from __future__ import annotations
+
+import logging
+
+import click
+
+__version__ = "0.1.0"
+
+# Configure logging similar to other projects
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+@click.version_option(version=__version__, prog_name="Aion SDK")
+def cli() -> None:
+    """Command line interface for the Aion Python SDK."""
+
+
+@cli.command(help="Run the AION Agent API server")
+def serve() -> None:
+    """Stub for running the AION Agent API server."""
+    welcome = """
+
+        Welcome to
+
+╔═╗╦╔═╗╔╗╔  ╔═╗╔═╗╔═╗╔╗╔╔╦╗  ╔═╗╔═╗╦
+╠═╣║║ ║║║║  ╠═╣║ ╦║╣ ║║║ ║   ╠═╣╠═╝║
+╩ ╩╩╚═╝╝╚╝  ╩ ╩╚═╝╚═╝╝╚╝ ╩   ╩ ╩╩  ╩
+
+- 🚀 API: http://127.0.0.1:8000
+- 📚 API Docs: http://127.0.0.1:8000/docs
+- 🖥️ Admin Interface: http://127.0.0.1:8000/api/admin
+
+This server provides endpoints for LangGraph agents.
+
+"""
+    logger.info(welcome)
+    logger.info(
+        "Patching langgraph_api", extra={"api_variant": "local_dev", "thread_name": "MainThread"}
+    )
+
+
+if __name__ == "__main__":
+    cli()
+

--- a/libs/aion-agent-cli/tests/test_cli.py
+++ b/libs/aion-agent-cli/tests/test_cli.py
@@ -1,0 +1,25 @@
+from click.testing import CliRunner
+from aion_agent_cli.cli import cli, __version__
+import logging
+
+
+def test_version() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+def test_help_lists_commands() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "serve" in result.output
+
+
+def test_serve_outputs_message(caplog) -> None:
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO):
+        result = runner.invoke(cli, ["serve"])
+    assert result.exit_code == 0
+    assert "Welcome to" in caplog.text


### PR DESCRIPTION
## Summary
- introduce a new `aion-agent-cli` library using Poetry
- implement a minimal CLI with `--help`, `--version` and `serve` stub
- add tests for the CLI
- document new project in `AGENTS.md`

## Testing
- `pytest libs/aion-agent-cli/tests -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', etc.)*