### PR TITLE
Improve CLI usage docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This repository is a monorepo containing multiple projects located primarily und
 - **_a2a-template-langgraph** – example implementation of an A2A protocol serving a LangGraph agent.
 - **_agent-workflow** – example implementation of a langgraph project using langgraph_api as a server
  - **aion-agent-api** – implementation of an A2A server wrapping a LangGraph project. Provides a structlog-based ``logging`` module for CLI tools.
-- **aion-agent-cli** – command line interface for the Aion Python SDK.
+ - **aion-agent-cli** – command line interface for the Aion Python SDK exposing the `aion` entry point.
 
 ## Additional guidelines
 

--- a/README.md
+++ b/README.md
@@ -3,5 +3,26 @@
 This repository contains multiple projects.
 
 - **cli** – the original AION Agent API project providing a CLI for deploying LangGraph workflows.
+- **aion-agent-cli** – command line interface for the Aion Python SDK.
+- **aion-agent-api** – A2A server wrapper for LangGraph projects.
 
 Each project manages its own dependencies and configuration.
+
+## Running the CLI
+
+Install ``aion-agent-cli`` as a dependency (for example with ``pip install -e
+libs/aion-agent-cli``). The package provides the ``aion`` command so you can
+launch the development server with:
+
+```bash
+poetry run aion serve
+```
+
+When working directly in this repository you can also run the CLI from the
+subproject for local development:
+
+```bash
+cd libs/aion-agent-cli
+poetry install
+poetry run aion serve
+```

--- a/libs/aion-agent-api/src/aion_agent_api/__init__.py
+++ b/libs/aion-agent-api/src/aion_agent_api/__init__.py
@@ -3,5 +3,5 @@
 from .server import A2AServer
 from .graph import initialize_graphs, get_graph
 
-__all__ = ["A2AServer", "initialize_graphs", "get_graph", "logging_config"]
+__all__ = ["A2AServer", "initialize_graphs", "get_graph"]
 

--- a/libs/aion-agent-api/tests/test_public_api.py
+++ b/libs/aion-agent-api/tests/test_public_api.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def test_public_api_exposes_all() -> None:
+    module = importlib.import_module("aion_agent_api")
+    assert isinstance(module.__all__, list)
+    for name in module.__all__:
+        assert hasattr(module, name)
+
+
+def test_star_import() -> None:
+    namespace: dict[str, object] = {}
+    exec("from aion_agent_api import *", namespace)
+    # Ensure a known symbol is imported
+    assert "A2AServer" in namespace

--- a/libs/aion-agent-cli/README.md
+++ b/libs/aion-agent-cli/README.md
@@ -7,3 +7,16 @@ This project provides a minimal CLI for running the Aion Agent API server.
 When ``structlog`` is available the CLI uses the same colorful logging style as
 ``_langgraph_cli`` via ``aion_agent_api.logging``. In more minimal
 environments it falls back to the standard library's basic configuration.
+
+## Usage
+
+Include ``aion-agent-cli`` as a dependency in your Poetry project. The
+package exposes the ``aion`` command via ``[tool.poetry.scripts]`` so once
+installed you can run:
+
+```bash
+poetry run aion serve
+```
+
+This will invoke ``aion_agent_cli.cli`` which in turn starts the local Agent
+API server.


### PR DESCRIPTION
## Summary
- clarify how to install `aion-agent-cli` in README
- document usage of the CLI from another Poetry project

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*