### PR TITLE
Fix logger setup for aion serve

### DIFF
--- a/libs/aion-agent-api/README.md
+++ b/libs/aion-agent-api/README.md
@@ -6,5 +6,6 @@ This package exposes a small `A2AServer` utility built on top of the
 Google `a2a-sdk` and Starlette.
 
 It also provides a ``logging`` module mirroring the colorful output used by
-``_langgraph_cli``. Applications can simply import ``aion_agent_api.logging`` to
-apply the configuration.
+``_langgraph_cli``. Importing ``aion_agent_api.logging`` automatically
+configures the root logger with a console handler so CLI tools immediately
+produce log output.

--- a/libs/aion-agent-api/src/aion_agent_api/logging.py
+++ b/libs/aion-agent-api/src/aion_agent_api/logging.py
@@ -13,7 +13,8 @@ LOG_JSON = log_env("LOG_JSON", cast=bool, default=False)
 LOG_COLOR = log_env("LOG_COLOR", cast=bool, default=True)
 LOG_LEVEL = log_env("LOG_LEVEL", cast=str, default="INFO")
 
-logging.getLogger().setLevel(LOG_LEVEL.upper())
+root_logger = logging.getLogger()
+root_logger.setLevel(LOG_LEVEL.upper())
 logging.getLogger("psycopg").setLevel(logging.WARNING)
 
 
@@ -100,3 +101,8 @@ structlog.configure(
     wrapper_class=structlog.stdlib.BoundLogger,
     cache_logger_on_first_use=True,
 )
+
+if not root_logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(Formatter("%(message)s", None, "%"))
+    root_logger.addHandler(handler)

--- a/libs/aion-agent-api/tests/test_logging.py
+++ b/libs/aion-agent-api/tests/test_logging.py
@@ -1,3 +1,4 @@
+import logging
 import structlog
 import aion_agent_api.logging as logconf
 
@@ -5,3 +6,8 @@ import aion_agent_api.logging as logconf
 def test_configures_structlog() -> None:
     logger = structlog.get_logger(__name__)
     assert isinstance(logger, structlog.stdlib.BoundLogger)
+
+
+def test_root_logger_has_handler() -> None:
+    root_logger = logging.getLogger()
+    assert root_logger.handlers, "Root logger should have a console handler"


### PR DESCRIPTION
## Summary
- configure root logger when `aion_agent_api.logging` is imported
- clarify README about logger initialization
- test that root logger is initialized

## Testing
- `pytest libs/aion-agent-cli/tests/test_cli.py libs/aion-agent-api/tests/test_logging.py -q` *(fails: ModuleNotFoundError: No module named 'structlog')*