### PR TITLE
Add langgraph config example

### DIFF
--- a/libs/aion-agent-api/README.md
+++ b/libs/aion-agent-api/README.md
@@ -9,3 +9,6 @@ It also provides a ``logging`` module mirroring the colorful output used by
 ``_langgraph_cli``. Importing ``aion_agent_api.logging`` automatically
 configures the root logger with a console handler so CLI tools immediately
 produce log output.
+
+Graphs are registered based on a ``langgraph.json`` file located in your project
+root. See ``langgraph.json.example`` for the expected format.

--- a/libs/aion-agent-api/langgraph.json.example
+++ b/libs/aion-agent-api/langgraph.json.example
@@ -1,0 +1,9 @@
+{
+    // Required. Map of graph IDs to paths where compiled graphs or graph-creating functions are defined
+    // Examples:
+    // - "./your_package/your_file.py:variable" where variable is a CompiledStateGraph instance
+    // - "./your_package/your_file.py:make_graph", where make_graph is a function that takes a config dictionary (langchain_core.runnables.RunnableConfig) and returns an instance of langgraph.graph.state.StateGraph or langgraph.graph.state.CompiledStateGraph
+    "graphs": {
+        "example_graph": "./src/path/to/your/module.py:graph_variable"
+    }
+}

--- a/libs/aion-agent-api/tests/test_graphs.py
+++ b/libs/aion-agent-api/tests/test_graphs.py
@@ -10,8 +10,9 @@ from aion_agent_api.graph import GRAPHS, initialize_graphs
 
 
 def test_initialize_graphs(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    graph_file = tmp_path / "my_graph.py"
-    graph_file.write_text(
+    module_path = tmp_path / "src" / "path" / "to" / "your" / "module.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text(
         """
 class DummyGraph:
     def compile(self):
@@ -21,7 +22,12 @@ def create_graph():
     return DummyGraph()
 """
     )
-    config = {"graphs": {"dummy": f"{graph_file}:create_graph"}}
+
+    config = {
+        "graphs": {
+            "example_graph": "./src/path/to/your/module.py:create_graph"
+        }
+    }
     (tmp_path / "langgraph.json").write_text(json.dumps(config))
 
     cwd = os.getcwd()
@@ -32,6 +38,6 @@ def create_graph():
     finally:
         os.chdir(cwd)
 
-    assert GRAPHS["dummy"] == "compiled"
+    assert GRAPHS["example_graph"] == "compiled"
     messages = [r.getMessage() for r in caplog.records]
-    assert any("Importing graph 'dummy'" in msg for msg in messages)
+    assert any("Importing graph 'example_graph'" in msg for msg in messages)


### PR DESCRIPTION
## Summary
- document langgraph.json layout for aion-agent-api
- update README to mention config file
- update graph registration test to mimic example structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*