### PR TITLE
Fix package paths and tests

### DIFF
--- a/libs/aion-agent-cli/README.md
+++ b/libs/aion-agent-cli/README.md
@@ -5,7 +5,7 @@ Command-line interface for the Aion Python SDK.
 This project provides a minimal CLI for running the Aion Agent API server.
 
 When ``structlog`` is available the CLI uses the same colorful logging style as
-``_langgraph_cli`` via ``aion_agent_api.logging``. In more minimal
+``_langgraph_cli`` via ``aion.server.langgraph.logging``. In more minimal
 environments it falls back to the standard library's basic configuration.
 
 ## Usage
@@ -18,5 +18,5 @@ installed you can run:
 poetry run aion serve
 ```
 
-This will invoke ``aion_agent_cli.cli`` which in turn starts the local Agent
+This will invoke ``aion.cli.cli`` which in turn starts the local Agent
 API server.

--- a/libs/aion-agent-cli/pyproject.toml
+++ b/libs/aion-agent-cli/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Command line interface for the Aion Python SDK"
 authors = ["Terminal Research Team <support@terminal.exchange>"]
 readme = "README.md"
-packages = [{include = "aion_agent_cli", from = "src"}]
+packages = [{include = "aion", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
@@ -19,4 +19,4 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-aion = "aion_agent_cli.cli:cli"
+aion = "aion.cli.cli:cli"

--- a/libs/aion-agent-cli/src/aion/cli/cli.py
+++ b/libs/aion-agent-cli/src/aion/cli/cli.py
@@ -11,7 +11,7 @@ __version__ = "0.1.0"
 try:  # pragma: no cover - optional dependency may not be installed
     import structlog
 
-    import aion_agent_api.logging  # noqa: F401 - triggers global configuration
+    import aion.server.langgraph.logging  # noqa: F401 - triggers global configuration
 
     logger = structlog.stdlib.get_logger(__name__)
 except Exception:  # pragma: no cover - structlog is optional for tests

--- a/libs/aion-agent-cli/tests/test_cli.py
+++ b/libs/aion-agent-cli/tests/test_cli.py
@@ -1,5 +1,5 @@
 from click.testing import CliRunner
-from aion_agent_cli.cli import cli, __version__
+from aion.cli.cli import cli, __version__
 import logging
 
 

--- a/libs/aion-server-langgraph/README.md
+++ b/libs/aion-server-langgraph/README.md
@@ -6,7 +6,7 @@ This package exposes a small `A2AServer` utility built on top of the
 Google `a2a-sdk` and Starlette.
 
 It also provides a ``logging`` module mirroring the colorful output used by
-``_langgraph_cli``. Importing ``aion_agent_api.logging`` automatically
+``_langgraph_cli``. Importing ``aion.server.langgraph.logging`` automatically
 configures the root logger with a console handler so CLI tools immediately
 produce log output.
 

--- a/libs/aion-server-langgraph/pyproject.toml
+++ b/libs/aion-server-langgraph/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A2A server wrapper for LangGraph projects"
 authors = ["Terminal Research Team <support@terminal.exchange>"]
 readme = "README.md"
-packages = [{include = "aion_agent_api", from = "src"}]
+packages = [{include = "aion", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/libs/aion-server-langgraph/tests/test_graphs.py
+++ b/libs/aion-server-langgraph/tests/test_graphs.py
@@ -6,7 +6,7 @@ import pytest
 
 import logging
 
-from aion_agent_api.graph import GRAPHS, initialize_graphs
+from aion.server.langgraph.graph import GRAPHS, initialize_graphs
 
 
 def test_initialize_graphs(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:

--- a/libs/aion-server-langgraph/tests/test_logging.py
+++ b/libs/aion-server-langgraph/tests/test_logging.py
@@ -1,6 +1,6 @@
 import logging
 import structlog
-import aion_agent_api.logging as logconf
+import aion.server.langgraph.logging as logconf
 
 
 def test_configures_structlog() -> None:

--- a/libs/aion-server-langgraph/tests/test_public_api.py
+++ b/libs/aion-server-langgraph/tests/test_public_api.py
@@ -2,7 +2,7 @@ import importlib
 
 
 def test_public_api_exposes_all() -> None:
-    module = importlib.import_module("aion_agent_api")
+    module = importlib.import_module("aion.server.langgraph")
     assert isinstance(module.__all__, list)
     for name in module.__all__:
         assert hasattr(module, name)
@@ -10,6 +10,6 @@ def test_public_api_exposes_all() -> None:
 
 def test_star_import() -> None:
     namespace: dict[str, object] = {}
-    exec("from aion_agent_api import *", namespace)
+    exec("from aion.server.langgraph import *", namespace)
     # Ensure a known symbol is imported
     assert "A2AServer" in namespace

--- a/libs/aion-server-langgraph/tests/test_server.py
+++ b/libs/aion-server-langgraph/tests/test_server.py
@@ -1,4 +1,4 @@
-from aion_agent_api.server import A2AServer
+from aion.server.langgraph.server import A2AServer
 from a2a.types import AgentCard, AgentCapabilities
 from a2a.server.request_handlers.request_handler import RequestHandler
 from starlette.applications import Starlette


### PR DESCRIPTION
## Summary
- update `pyproject.toml` package settings for new package layout
- fix imports in aion-agent-cli and aion-server-langgraph
- update README references
- update tests to use new import paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*