### PR TITLE
Update CLI to launch example server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository is a monorepo containing multiple projects located primarily und
 - **_agent-workflow** – example implementation of a langgraph project using langgraph_api as a server
  - **aion-agent-api** – implementation of an A2A server wrapping a LangGraph project. Provides a structlog-based ``logging`` module for CLI tools.
  - **aion-agent-cli** – command line interface for the Aion Python SDK exposing the `aion` entry point.
+ - **aion-server-langgraph** – example Google A2A server running a LangGraph agent.
 
 ## Additional guidelines
 

--- a/libs/aion-agent-cli/src/aion/cli/cli.py
+++ b/libs/aion-agent-cli/src/aion/cli/cli.py
@@ -29,27 +29,23 @@ def cli() -> None:
 
 
 @cli.command(help="🚀 Run the AION Agent API server")
-def serve() -> None:
-    """Stub for running the AION Agent API server."""
-    welcome = """
-
-        Welcome to
-
-╔═╗╦╔═╗╔╗╔  ╔═╗╔═╗╔═╗╔╗╔╔╦╗  ╔═╗╔═╗╦
-╠═╣║║ ║║║║  ╠═╣║ ╦║╣ ║║║ ║   ╠═╣╠═╝║
-╩ ╩╩╚═╝╝╚╝  ╩ ╩╚═╝╚═╝╝╚╝ ╩   ╩ ╩╩  ╩
-
-- 🚀 API: http://127.0.0.1:8000
-- 📚 API Docs: http://127.0.0.1:8000/docs
-- 🖥️ Admin Interface: http://127.0.0.1:8000/api/admin
-
-This server provides endpoints for LangGraph agents.
-
-"""
-    logger.info(welcome)
+@click.option("--host", default="localhost", show_default=True, help="Server host")
+@click.option("--port", default=10000, show_default=True, help="Server port")
+def serve(host: str, port: int) -> None:
+    """Run the example AION Agent API server."""
     logger.info(
-        "Patching langgraph_api", extra={"api_variant": "local_dev", "thread_name": "MainThread"}
+        "Starting AION Agent API server",
+        extra={"host": host, "port": port},
     )
+    try:
+        from aion.server.langgraph.__main__ import main as server_main
+    except Exception as exc:  # pragma: no cover - optional dependency may fail
+        logger.error("Failed to import server", exc_info=exc)
+        raise click.ClickException(
+            "Unable to start server. Is aion-server-langgraph installed?"
+        ) from exc
+
+    server_main.callback(host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/libs/aion-agent-cli/tests/test_cli.py
+++ b/libs/aion-agent-cli/tests/test_cli.py
@@ -1,6 +1,8 @@
 from click.testing import CliRunner
 from aion.cli.cli import cli, __version__
 import logging
+import types
+import sys
 
 
 def test_version() -> None:
@@ -17,9 +19,18 @@ def test_help_lists_commands() -> None:
     assert "serve" in result.output
 
 
-def test_serve_outputs_message(caplog) -> None:
+def test_serve_invokes_server(monkeypatch) -> None:
+    """Ensure the serve command delegates to the example server."""
+    called = {}
+
+    def fake_server(host: str, port: int) -> None:
+        called["args"] = (host, port)
+
+    mod = types.SimpleNamespace(main=types.SimpleNamespace(callback=fake_server))
+    monkeypatch.setitem(sys.modules, "aion.server.langgraph.__main__", mod)
+
     runner = CliRunner()
-    with caplog.at_level(logging.INFO):
-        result = runner.invoke(cli, ["serve"])
+    result = runner.invoke(cli, ["serve", "--host", "0.0.0.0", "--port", "1234"])
+
     assert result.exit_code == 0
-    assert "Welcome to" in caplog.text
+    assert called["args"] == ("0.0.0.0", 1234)


### PR DESCRIPTION
## Summary
- allow `aion serve` to run the example server from `aion-server-langgraph`
- add unit test to ensure serve delegates to the example server
- document new project in `AGENTS.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*