### PR TITLE
Fix aion-cli packaging

### DIFF
--- a/libs/aion-cli/src/aion/__init__.py
+++ b/libs/aion-cli/src/aion/__init__.py
@@ -1,0 +1,3 @@
+"""Namespace package for Aion command-line utilities."""
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/libs/aion-cli/src/aion/cli/cli.py
+++ b/libs/aion-cli/src/aion/cli/cli.py
@@ -48,7 +48,16 @@ def serve(host: str, port: int) -> None:
 
     server_main.callback(host=host, port=port)
     
-def welcome_message(host: str, port: int):
+def welcome_message(host: str, port: int) -> str:
+    """Return an ASCII welcome banner for the API server.
+
+    Args:
+        host: Hostname where the server is running.
+        port: Port number where the server is running.
+
+    Returns:
+        A formatted multi-line string containing usage information.
+    """
     return """
 
         Welcome to


### PR DESCRIPTION
## Summary
- add missing namespace package file for aion-cli
- add docstring for the `welcome_message` helper

## Testing
- `PYTHONPATH=$(pwd)/libs/aion-cli/src pytest libs/aion-cli/tests/test_cli.py -q`