### PR TITLE
Fix server imports and CLI banner formatting

### DIFF
--- a/libs/aion-cli/src/aion/cli/cli.py
+++ b/libs/aion-cli/src/aion/cli/cli.py
@@ -58,7 +58,7 @@ def welcome_message(host: str, port: int) -> str:
     Returns:
         A formatted multi-line string containing usage information.
     """
-    return """
+    return f"""
 
         Welcome to
 

--- a/libs/aion-server-langgraph/src/aion/server/langgraph/__main__.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/__main__.py
@@ -13,9 +13,8 @@ from a2a.types import (
     AgentCard,
     AgentSkill,
 )
-from agent import CurrencyAgent
-from agent_executor import CurrencyAgentExecutor
-from agents.langgraph.agent import CurrencyAgent
+from .a2a.agent import CurrencyAgent
+from .a2a.agent_executor import CurrencyAgentExecutor
 from dotenv import load_dotenv
 
 

--- a/libs/aion-server-langgraph/src/aion/server/langgraph/a2a/__init__.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/a2a/__init__.py
@@ -1,0 +1,6 @@
+"""LangGraph A2A example agent modules."""
+
+__all__ = ["CurrencyAgent", "CurrencyAgentExecutor"]
+
+from .agent import CurrencyAgent
+from .agent_executor import CurrencyAgentExecutor

--- a/libs/aion-server-langgraph/src/aion/server/langgraph/a2a/agent_executor.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/a2a/agent_executor.py
@@ -17,7 +17,7 @@ from a2a.utils import (
     new_task,
 )
 from a2a.utils.errors import ServerError
-from agent import CurrencyAgent
+from .agent import CurrencyAgent
 
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- fix CLI welcome banner to correctly substitute host and port
- update server modules to use package-relative imports
- make `a2a` a proper package with `__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*