### PR TITLE
Fix structlog configuration for server logging

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/langgraph/logging.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/logging.py
@@ -99,7 +99,7 @@ structlog.configure(
     ],
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
-    cache_logger_on_first_use=False,
+    cache_logger_on_first_use=True,
 )
 
 if not root_logger.handlers:


### PR DESCRIPTION
## Summary
- ensure structlog returns `BoundLogger` by caching loggers
- update `logging.py` to enable cache

## Testing
- `poetry run pytest` *(fails: collected 0 items / 4 skipped)*