### PR TITLE
Fix structlog configuration

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/langgraph/logging.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/logging.py
@@ -98,7 +98,7 @@ structlog.configure(
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
     logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.stdlib.BoundLogger,
+    wrapper_class=structlog.make_filtering_bound_logger(root_logger.level),
     cache_logger_on_first_use=True,
 )
 


### PR DESCRIPTION
## Summary
- fix structlog logger class to satisfy tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*