### PR TITLE
Use graph from config in Aion server

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/langgraph/a2a/agent_executor.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/a2a/agent_executor.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import Event, EventQueue
@@ -25,10 +26,13 @@ logger = logging.getLogger(__name__)
 
 
 class CurrencyAgentExecutor(AgentExecutor):
-    """Currency Conversion AgentExecutor Example."""
+    """Currency Conversion ``AgentExecutor`` example."""
 
-    def __init__(self):
-        self.agent = CurrencyAgent()
+    def __init__(self, graph: Any) -> None:
+        """Create the executor with the given graph."""
+
+        self.agent = CurrencyAgent(config_path=None)
+        self.agent.graph = graph
 
     async def execute(
         self,

--- a/libs/aion-server-langgraph/tests/test_currency_agent.py
+++ b/libs/aion-server-langgraph/tests/test_currency_agent.py
@@ -1,0 +1,46 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("a2a")
+
+from aion.server.langgraph.a2a.agent import CurrencyAgent
+from aion.server.langgraph.graph import GRAPHS
+
+
+def test_currency_agent_uses_first_registered_graph(tmp_path: Path) -> None:
+    module_path = tmp_path / "mod.py"
+    module_path.write_text(
+        """
+class DummyGraph:
+    pass
+
+def create() -> DummyGraph:
+    return DummyGraph()
+"""
+    )
+    config = {"graphs": {"g1": "./mod.py:create"}}
+    cfg_path = tmp_path / "langgraph.json"
+    cfg_path.write_text(json.dumps(config))
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        agent = CurrencyAgent(config_path=str(cfg_path))
+        assert agent.graph is GRAPHS["g1"]
+    finally:
+        os.chdir(cwd)
+
+
+def test_currency_agent_no_graphs(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "langgraph.json"
+    cfg_path.write_text(json.dumps({"graphs": {}}))
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        with pytest.raises(SystemExit):
+            CurrencyAgent(config_path=str(cfg_path))
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- update `CurrencyAgent` to load the first registered graph from `langgraph.json`
- add safety checks and logging when graphs aren't available
- inject the configured graph into `CurrencyAgentExecutor`
- initialize graphs in the CLI entrypoint and use the loaded graph
- add unit tests for `CurrencyAgent` behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*