### PR TITLE
Fix lazy graph loading and structlog config

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/langgraph/a2a/agent.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/a2a/agent.py
@@ -56,8 +56,14 @@ class ResponseFormat(BaseModel):
 class LanggraphAgent:
     """Simple agent that delegates execution to a configured LangGraph."""
 
-    def __init__(self, graph: Any) -> None:
+    def __init__(self, graph: Any | None) -> None:
         """Initialize the agent using the first registered LangGraph."""
+        if graph is None:
+            if not GRAPHS:
+                initialize_graphs()
+            if not GRAPHS:
+                raise SystemExit(1)
+            graph = next(iter(GRAPHS.values()))
         self.graph = graph
         
     def invoke(self, query: str, sessionId: str) -> str:

--- a/libs/aion-server-langgraph/src/aion/server/langgraph/logging.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/logging.py
@@ -98,7 +98,7 @@ structlog.configure(
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
     logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.make_filtering_bound_logger(root_logger.level),
+    wrapper_class=structlog.stdlib.BoundLogger,
     cache_logger_on_first_use=True,
 )
 


### PR DESCRIPTION
## Summary
- automatically load graphs on first access
- init agent with first graph when none supplied
- ensure structlog returns a BoundLogger

## Testing
- `pytest -q libs/aion-server-langgraph/tests`