### PR TITLE
Remove fallback A2A models

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/db/models.py
+++ b/libs/aion-server-langgraph/src/aion/server/db/models.py
@@ -10,21 +10,10 @@ from pydantic import BaseModel
 
 try:  # pragma: no cover - optional dependency
     from a2a.types import Artifact, Task
-except Exception:  # pragma: no cover - test environment without dependency
-    class Artifact(BaseModel):
-        """Fallback Artifact model."""
-
-        artifactId: str
-        name: str | None = None
-        parts: list
-        metadata: dict | None = None
-
-    class Task(BaseModel):
-        """Fallback Task model."""
-
-        id: str
-        contextId: str
-        status: str | None = None
+except Exception as exc:  # pragma: no cover - explicit failure if missing
+    raise ImportError(
+        "The 'a2a-sdk' package is required to use these models"
+    ) from exc
 
 
 class ThreadRecord(BaseModel):


### PR DESCRIPTION
## Summary
- fail fast if `a2a-sdk` is not installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cba417c4083238780b11228ff63f7