### PR TITLE
Ensure migrations run on server startup

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/langgraph/__main__.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/__main__.py
@@ -24,6 +24,7 @@ from .a2a.agent import LanggraphAgent
 from .a2a.agent_executor import LanggraphAgentExecutor
 from .graph import GRAPHS, get_graph, initialize_graphs
 from aion.server.db import get_config, test_connection
+from aion.server.db.migrations.env import run_migrations
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,11 @@ def main(host, port):
         cfg = get_config()
         if cfg:
             has_db = test_connection(cfg.url)
+            if has_db:
+                try:
+                    run_migrations()
+                except Exception as exc:  # pragma: no cover - migration failure
+                    logger.error("Failed to run migrations: %s", exc)
         else:
             has_db = False
             logger.info(

--- a/libs/aion-server-langgraph/tests/test_main.py
+++ b/libs/aion-server-langgraph/tests/test_main.py
@@ -1,0 +1,26 @@
+import importlib
+from unittest import mock
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("a2a")
+
+
+def test_main_runs_migrations(monkeypatch):
+    monkeypatch.setenv("POSTGRES_URL", "postgresql://example")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "key")
+    module = importlib.import_module("aion.server.langgraph.__main__")
+
+    monkeypatch.setattr(module, "test_connection", lambda url: True)
+    called = {}
+    monkeypatch.setattr(module, "run_migrations", lambda: called.setdefault("ran", True))
+    monkeypatch.setattr(module, "initialize_graphs", lambda: module.GRAPHS.setdefault("g", object()))
+    monkeypatch.setattr(module, "PostgresTaskStore", lambda: object())
+    monkeypatch.setattr(module, "LanggraphAgentExecutor", lambda g: object())
+    monkeypatch.setattr(module, "InMemoryTaskStore", lambda: object())
+    monkeypatch.setattr(module, "A2AStarletteApplication", lambda agent_card, http_handler: mock.Mock(build=lambda: "app"))
+    monkeypatch.setattr(module, "httpx", mock.Mock(AsyncClient=lambda: mock.Mock()))
+    monkeypatch.setattr(module, "uvicorn", mock.Mock(run=lambda app, host, port: None))
+
+    module.main.callback(host="localhost", port=10000)
+    assert called.get("ran")


### PR DESCRIPTION
## Summary
- run Alembic migrations when the Postgres connection succeeds during server startup
- test that the migrations function is invoked

## Testing
- `pytest`
- `pytest -c /dev/null libs/aion-server-langgraph/tests/test_main.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683cc405948c8323b3fa1b95d486f498