### PR TITLE
Fix invalid key in aion-server-langgraph pyproject

### DIFF
--- a/libs/aion-server-langgraph/pyproject.toml
+++ b/libs/aion-server-langgraph/pyproject.toml
@@ -15,7 +15,7 @@ structlog = "^24.1.0"
 httpx = "^0.28.1"
 pydantic = "^2.10.6"
 python-dotenv = "^1.1.0"
-psycopg[binary] = "^3.1"
+"psycopg[binary]" = "^3.1"
 alembic = "^1.13"
 SQLAlchemy = "^2.0"
 


### PR DESCRIPTION
## Summary
- fix invalid TOML syntax in `aion-server-langgraph` by quoting the key `psycopg[binary]`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683cc5b319948323ac612d087dd4db64