### PR TITLE
Fix migrations env import

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/db/migrations/env.py
+++ b/libs/aion-server-langgraph/src/aion/server/db/migrations/env.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 from alembic import context
+from alembic.config import Config
 from sqlalchemy import create_engine
 
 from aion.server.db import get_config
+
+# ``alembic.context`` exposes ``config`` only when executed via Alembic's
+# command line utilities. When this module is imported directly (e.g. during
+# server startup), the attribute is missing. Create a basic ``Config`` object in
+# that case so that configuration options can still be set.
+if not hasattr(context, "config"):
+    context.config = Config()  # type: ignore[attr-defined]
 
 config = context.config
 

--- a/libs/aion-server-langgraph/tests/test_migrations_env.py
+++ b/libs/aion-server-langgraph/tests/test_migrations_env.py
@@ -1,0 +1,15 @@
+import importlib
+import pytest
+
+pytest.importorskip("alembic")
+import alembic.context
+
+
+def test_import_env_without_alembic_config(monkeypatch):
+    """Ensure migrations env can load when context lacks ``config``."""
+    monkeypatch.delattr(alembic.context, "config", raising=False)
+
+    module = importlib.import_module("aion.server.db.migrations.env")
+    importlib.reload(module)
+
+    assert hasattr(alembic.context, "config")


### PR DESCRIPTION
## Summary
- make Alembic env create a Config object when imported directly
- test migrations env import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cc960b578832381e678263a90a7ba