### PR TITLE
Fix migrations env import error

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/db/migrations/env.py
+++ b/libs/aion-server-langgraph/src/aion/server/db/migrations/env.py
@@ -41,9 +41,16 @@ def run_migrations() -> None:
             context.run_migrations()
 
 
-if context.is_offline_mode():  # pragma: no cover - offline migrations
+def run_offline_migrations() -> None:
+    """Run migrations in offline mode."""
+
     context.configure(url=DATABASE_URL)
     with context.begin_transaction():
         context.run_migrations()
-else:
-    run_migrations()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI invocation
+    if context.is_offline_mode():
+        run_offline_migrations()
+    else:
+        run_migrations()


### PR DESCRIPTION
## Summary
- fix NameError on import in migrations env by moving offline logic into a `run_offline_migrations` function
- gate direct execution on `__main__`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683cca51ed088323b4d85d6737047058