### PR TITLE
Fix Postgres DSN for SQLAlchemy

### DIFF
--- a/libs/aion-server-langgraph/.env.example
+++ b/libs/aion-server-langgraph/.env.example
@@ -3,3 +3,4 @@
 # (Optional) Postgres Configuration
 # By default, an in-memory data store will be used.
 POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgres
+

--- a/libs/aion-server-langgraph/src/aion/server/db/__init__.py
+++ b/libs/aion-server-langgraph/src/aion/server/db/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "AION_DB_NAMESPACE",
     "DatabaseConfig",
     "get_config",
+    "sqlalchemy_url",
     "test_connection",
 ]
 
@@ -58,3 +59,27 @@ def test_connection(url: str) -> bool:
     except Exception as exc:  # pragma: no cover - connection failures
         logger.error("Could not connect to Postgres: %s", exc)
         return False
+
+
+def sqlalchemy_url(url: str) -> str:
+    """Return a SQLAlchemy connection URL using the ``psycopg`` driver.
+
+    SQLAlchemy requires the ``postgresql+psycopg://`` protocol when using
+    ``psycopg`` version 3. This helper ensures the correct prefix is used
+    without forcing callers to specify it in their environment variable.
+
+    Args:
+        url: The configured connection URL.
+
+    Returns:
+        The URL formatted for SQLAlchemy.
+    """
+
+    prefix = "postgresql+psycopg://"
+    if url.startswith(prefix) or not url:
+        return url
+    if url.startswith("postgresql://"):
+        return prefix + url[len("postgresql://") :]
+    if url.startswith("postgres://"):
+        return prefix + url[len("postgres://") :]
+    return url

--- a/libs/aion-server-langgraph/src/aion/server/db/migrations/env.py
+++ b/libs/aion-server-langgraph/src/aion/server/db/migrations/env.py
@@ -8,7 +8,7 @@ from alembic import context
 from alembic.config import Config
 from sqlalchemy import create_engine
 
-from aion.server.db import get_config
+from aion.server.db import get_config, sqlalchemy_url
 
 # ``alembic.context`` exposes ``config`` only when executed via Alembic's
 # command line utilities. When this module is imported directly (e.g. during
@@ -25,7 +25,7 @@ config.set_main_option("script_location", str(script_location))
 
 cfg = get_config()
 DATABASE_URL = cfg.url if cfg else ""
-config.set_main_option("sqlalchemy.url", DATABASE_URL)
+config.set_main_option("sqlalchemy.url", sqlalchemy_url(DATABASE_URL))
 
 
 def _get_engine() -> "Engine":
@@ -34,8 +34,9 @@ def _get_engine() -> "Engine":
     if not cfg:
         raise RuntimeError("No database configured")
 
-    config.set_main_option("sqlalchemy.url", cfg.url)
-    return create_engine(cfg.url)
+    url = sqlalchemy_url(cfg.url)
+    config.set_main_option("sqlalchemy.url", url)
+    return create_engine(url)
 
 
 def run_migrations() -> None:
@@ -52,7 +53,7 @@ def run_offline_migrations() -> None:
     """Run migrations in offline mode."""
 
     cfg = get_config()
-    url = cfg.url if cfg else ""
+    url = sqlalchemy_url(cfg.url) if cfg else ""
     context.configure(url=url)
     with context.begin_transaction():
         context.run_migrations()

--- a/libs/aion-server-langgraph/tests/test_migrations_env.py
+++ b/libs/aion-server-langgraph/tests/test_migrations_env.py
@@ -43,5 +43,5 @@ def test_run_migrations_uses_runtime_env(monkeypatch):
 
     module.run_migrations()
 
-    assert created.get("url") == "postgresql://example"
+    assert created.get("url") == "postgresql+psycopg://example"
     assert created.get("ran")


### PR DESCRIPTION
## Summary
- add `sqlalchemy_url` helper to auto-convert DSNs to use the psycopg driver
- apply helper in Alembic env so migrations use the correct protocol
- revert `.env.example` and docs to plain `postgresql://` URLs
- update unit tests for new helper behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cce188044832396c5d6e5c29eb7f7