### PR TITLE
Fix migrations startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This repository is a monorepo containing multiple projects located primarily und
 - **_a2a-template-langgraph** – example implementation of an A2A protocol serving a LangGraph agent.
 - **_agent-workflow** – example implementation of a langgraph project using langgraph_api as a server
 - **aion-agent-cli** – command line interface for the Aion Python SDK exposing the `aion` entry point.
-- **aion-server-langgraph** – example Google A2A server running a LangGraph agent. Includes a Postgres database interface and task store.
+- **aion-server-langgraph** – example Google A2A server running a LangGraph agent. Includes a Postgres database interface, task store, and Alembic migration helpers.
 
 ## Additional guidelines
 

--- a/libs/aion-server-langgraph/src/aion/server/db/migrations/__init__.py
+++ b/libs/aion-server-langgraph/src/aion/server/db/migrations/__init__.py
@@ -1,0 +1,18 @@
+"""Utilities for applying database migrations programmatically."""
+
+from __future__ import annotations
+
+from alembic import command
+
+from .env import config
+
+__all__ = ["upgrade_to_head"]
+
+
+def upgrade_to_head() -> None:
+    """Upgrade the database schema to the latest revision.
+
+    This function delegates to :func:`alembic.command.upgrade` using the
+    configuration defined in :mod:`aion.server.db.migrations.env`.
+    """
+    command.upgrade(config, "head")

--- a/libs/aion-server-langgraph/src/aion/server/langgraph/__main__.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/__main__.py
@@ -24,7 +24,7 @@ from .a2a.agent import LanggraphAgent
 from .a2a.agent_executor import LanggraphAgentExecutor
 from .graph import GRAPHS, get_graph, initialize_graphs
 from aion.server.db import get_config, test_connection
-from aion.server.db.migrations.env import run_migrations
+from aion.server.db.migrations import upgrade_to_head
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ def main(host, port):
             has_db = test_connection(cfg.url)
             if has_db:
                 try:
-                    run_migrations()
+                    upgrade_to_head()
                 except Exception as exc:  # pragma: no cover - migration failure
                     logger.error("Failed to run migrations: %s", exc)
         else:

--- a/libs/aion-server-langgraph/tests/test_main.py
+++ b/libs/aion-server-langgraph/tests/test_main.py
@@ -13,7 +13,7 @@ def test_main_runs_migrations(monkeypatch):
 
     monkeypatch.setattr(module, "test_connection", lambda url: True)
     called = {}
-    monkeypatch.setattr(module, "run_migrations", lambda: called.setdefault("ran", True))
+    monkeypatch.setattr(module, "upgrade_to_head", lambda: called.setdefault("ran", True))
     monkeypatch.setattr(module, "initialize_graphs", lambda: module.GRAPHS.setdefault("g", object()))
     monkeypatch.setattr(module, "PostgresTaskStore", lambda: object())
     monkeypatch.setattr(module, "LanggraphAgentExecutor", lambda g: object())


### PR DESCRIPTION
## Summary
- add a utility to upgrade DB schema programmatically
- call new helper when server boots
- keep tests in sync with the new entry point
- document migration helper in repo guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cd631828c8323a9ade05db79924b1