### PR TITLE
Add debug logging for migrations

### DIFF
--- a/libs/aion-server-langgraph/tests/test_migrations_env.py
+++ b/libs/aion-server-langgraph/tests/test_migrations_env.py
@@ -1,4 +1,6 @@
 import importlib
+import logging
+from contextlib import nullcontext
 import pytest
 
 pytest.importorskip("alembic")
@@ -45,3 +47,46 @@ def test_run_migrations_uses_runtime_env(monkeypatch):
 
     assert created.get("url") == "postgresql+psycopg://example"
     assert created.get("ran")
+
+
+def test_run_migrations_logs_steps(monkeypatch, caplog):
+    """Ensure each migration emits debug logs when executed."""
+
+    monkeypatch.delenv("POSTGRES_URL", raising=False)
+    module = importlib.import_module("aion.server.db.migrations.env")
+    importlib.reload(module)
+
+    monkeypatch.setenv("POSTGRES_URL", "postgresql://example")
+
+    class DummyEngine:
+        def connect(self):
+            class Conn:
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    pass
+
+            return Conn()
+
+    def fake_configure(**kwargs):
+        caplog.before = kwargs.get("process_revision_directives")
+        caplog.after = kwargs.get("on_version_apply")
+
+    def fake_run_migrations():
+        rev = type("Rev", (), {"path": "foo.py"})()
+        if caplog.before:
+            caplog.before(module.context, rev, [])
+        if caplog.after:
+            caplog.after(module.context, rev, [])
+
+    monkeypatch.setattr(module, "create_engine", lambda url: DummyEngine())
+    monkeypatch.setattr(module.context, "configure", fake_configure)
+    monkeypatch.setattr(module.context, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(module.context, "begin_transaction", lambda: nullcontext())
+
+    with caplog.at_level(logging.DEBUG):
+        module.run_migrations()
+
+    assert "Running migration foo.py" in caplog.text
+    assert "Completed migration foo.py" in caplog.text


### PR DESCRIPTION
## Summary
- add logger hooks to log migration start and completion
- test that migrations log each file

## Testing
- `pytest -k migrations_env -vv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ce49c8bcc8323b02b23c6c87d28f7