### PR TITLE
Improve DB connection logging

### DIFF
--- a/libs/aion-server-langgraph/src/aion/server/db/__init__.py
+++ b/libs/aion-server-langgraph/src/aion/server/db/__init__.py
@@ -54,7 +54,22 @@ def test_connection(url: str) -> bool:
     try:
         conn = psycopg.connect(url)
         conn.close()
-        logger.info("Successfully connected to Postgres")
+        # Parse connection info for more helpful logging
+        try:
+            from urllib.parse import urlparse
+
+            parsed = urlparse(url)
+            host = parsed.hostname or ""
+            port = f":{parsed.port}" if parsed.port else ""
+            dbname = parsed.path.lstrip("/") if parsed.path else ""
+            dbpart = f"/{dbname}" if dbname else ""
+            details = f"{host}{port}{dbpart}" if (host or dbpart) else ""
+        except Exception:
+            details = ""
+        if details:
+            logger.info("Successfully connected to Postgres at %s", details)
+        else:
+            logger.info("Successfully connected to Postgres")
         return True
     except Exception as exc:  # pragma: no cover - connection failures
         logger.error("Could not connect to Postgres: %s", exc)

--- a/libs/aion-server-langgraph/src/aion/server/langgraph/__main__.py
+++ b/libs/aion-server-langgraph/src/aion/server/langgraph/__main__.py
@@ -45,8 +45,10 @@ def main(host, port):
         if cfg:
             has_db = test_connection(cfg.url)
             if has_db:
+                logger.debug("Running database migrations")
                 try:
                     upgrade_to_head()
+                    logger.debug("Database migrations completed")
                 except Exception as exc:  # pragma: no cover - migration failure
                     logger.error("Failed to run migrations: %s", exc)
         else:

--- a/libs/aion-server-langgraph/tests/test_db.py
+++ b/libs/aion-server-langgraph/tests/test_db.py
@@ -56,7 +56,7 @@ def test_test_connection_success(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         assert test_connection("postgresql://example")
     assert conn.closed
-    assert "Successfully connected to Postgres" in caplog.text
+    assert "Successfully connected to Postgres at example" in caplog.text
 
 
 def test_test_connection_failure(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- show DB connection details when Postgres connection succeeds
- log when migrations start and finish
- adjust tests for updated log messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d03283b0c8323abc94e8c040bb61f