### PR TITLE
Update server init to use aion.yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This repository is a monorepo containing multiple projects located primarily und
 - **_a2a-template-langgraph** – example implementation of an A2A protocol serving a LangGraph agent.
 - **_agent-workflow** – example implementation of a langgraph project using langgraph_api as a server
 - **aion-agent-cli** – command line interface for the Aion Python SDK exposing the `aion` entry point.
-- **aion-server-langgraph** – example Google A2A server running a LangGraph agent. Includes a Postgres database interface, task store, and Alembic migration helpers.
+- **aion-server-langgraph** – example Google A2A server running a LangGraph agent. Includes a Postgres database interface, task store, and Alembic migration helpers. Graphs are configured via `aion.yaml`.
 
 ## Additional guidelines
 

--- a/libs/aion-server-langgraph/README.md
+++ b/libs/aion-server-langgraph/README.md
@@ -10,5 +10,5 @@ It also provides a ``logging`` module mirroring the colorful output used by
 configures the root logger with a console handler so CLI tools immediately
 produce log output.
 
-Graphs are registered based on a ``langgraph.json`` file located in your project
-root. See ``langgraph.json.example`` for the expected format.
+Graphs are registered based on an ``aion.yaml`` file located in your project
+root. See ``aion.yaml.example`` for the expected format.

--- a/libs/aion-server-langgraph/tests/test_graphs.py
+++ b/libs/aion-server-langgraph/tests/test_graphs.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 
@@ -26,12 +25,12 @@ def create_graph():
 """
     )
 
-    config = {
-        "graphs": {
-            "example_graph": "./src/path/to/your/module.py:create_graph"
-        }
-    }
-    (tmp_path / "langgraph.json").write_text(json.dumps(config))
+    config = (
+        "aion:\n"
+        "  graph:\n"
+        "    example_graph: \"./src/path/to/your/module.py:create_graph\"\n"
+    )
+    (tmp_path / "aion.yaml").write_text(config)
 
     cwd = os.getcwd()
     os.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- search for `aion.yaml` instead of `langgraph.json` when registering graphs
- provide lightweight YAML loader for config parsing
- update README and repo docs
- update unit tests to use the new config file format

## Testing
- `pytest -q libs/aion-server-langgraph/tests`

------
https://chatgpt.com/codex/tasks/task_e_683df356e6448323902d4758b930c835