### PR TITLE
Implement ApiClient chat completions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ This repository is a monorepo containing multiple projects located primarily und
 - **_agent-workflow** – example implementation of a langgraph project using langgraph_api as a server
 - **aion-agent-cli** – command line interface for the Aion Python SDK exposing the `aion` entry point.
 - **aion-server-langgraph** – example Google A2A server running a LangGraph agent. Includes a Postgres database interface, task store, and Alembic migration helpers. Graphs are configured via `aion.yaml`.
-- **aion-api-client** – websocket GraphQL client for the Aion API.
+- **aion-api-client** – provides a low level GraphQL client and a high level
+  `ApiClient` interface for the Aion API.
 
 ## Additional guidelines
 

--- a/libs/aion-api-client/src/aion/__init__.py
+++ b/libs/aion-api-client/src/aion/__init__.py
@@ -1,0 +1,15 @@
+"""Namespace package for Aion SDK libraries.
+
+This package exposes the :class:`ApiClient` and GraphQL data models for
+consumers.
+"""
+
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+
+from .api_client import ApiClient, settings  # noqa: E402
+from .gql.client import GqlClient  # noqa: E402
+from .gql import generated  # noqa: E402
+
+__all__ = ["ApiClient", "GqlClient", "settings", "generated"]

--- a/libs/aion-api-client/src/aion/api_client/__init__.py
+++ b/libs/aion-api-client/src/aion/api_client/__init__.py
@@ -1,6 +1,6 @@
-"""Websocket GraphQL client for the Aion API."""
+"""High level API client for the Aion API."""
 
-from .client import AionApiClient
+from .client import ApiClient
 from .settings import settings
 
-__all__ = ["AionApiClient", "settings"]
+__all__ = ["ApiClient", "settings"]

--- a/libs/aion-api-client/src/aion/api_client/client.py
+++ b/libs/aion-api-client/src/aion/api_client/client.py
@@ -1,76 +1,64 @@
-"""GraphQL client for communicating with the Aion API."""
+"""High level programmatic interface for the Aion API."""
 
 from __future__ import annotations
 
-import logging
-import os
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, AsyncGenerator, Iterable, Optional
 
-import httpx
-import jwt
-from gql import Client, gql
-from gql.transport.websockets import WebsocketsTransport
+from ..gql.client import GqlClient
 
-from .settings import settings
+CHAT_COMPLETIONS_SUBSCRIPTION = """
+subscription ChatCompletions($request: ChatCompletionRequest!) {
+  chatCompletionStream(request: $request) {
+    ... on ChatCompletionStreamResponseChunk {
+      response {
+        id
+        created
+        model
+        choices {
+          index
+          delta {
+            role
+            content
+          }
+          finishReason
+        }
+      }
+    }
+    ... on ChatCompletionStreamError {
+      message
+    }
+    ... on ChatCompletionStreamComplete {
+      done
+    }
+  }
+}
+"""
 
-LOGGER = logging.getLogger(__name__)
 
+class ApiClient:
+    """Programmatic interface exposing Aion API functionality."""
 
-@dataclass
-class Token:
-    """Represents an authentication token."""
+    def __init__(self, gql_client: Optional[GqlClient] = None) -> None:
+        self._gql = gql_client or GqlClient()
 
-    value: str
-    expires_at: datetime
+    async def chat_completions(
+        self,
+        model: str,
+        messages: Iterable[dict[str, str]],
+        *,
+        stream: bool = True,
+    ) -> AsyncGenerator[Any, None]:
+        """Request a chat completion stream.
 
-    @classmethod
-    def from_jwt(cls, token: str) -> "Token":
-        payload = jwt.decode(token, options={"verify_signature": False})
-        exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
-        return cls(value=token, expires_at=exp)
+        Args:
+            model: Identifier of the model to use.
+            messages: Sequence of message dictionaries with ``role`` and ``content``.
+            stream: Whether to request a streaming response.
 
-    @property
-    def expired(self) -> bool:
-        return datetime.now(tz=timezone.utc) >= self.expires_at
+        Yields:
+            GraphQL response chunks from the ``chatCompletionStream`` subscription.
+        """
 
-
-class AionApiClient:
-    """Client for the Aion GraphQL API using websockets."""
-
-    def __init__(self) -> None:
-        self.client_id = os.getenv("AION_CLIENT_ID")
-        self.secret = os.getenv("AION_SECRET")
-        if not self.client_id or not self.secret:
-            LOGGER.error(
-                "AION_CLIENT_ID and AION_SECRET environment variables must be set"
-            )
-        self._token: Optional[Token] = None
-        self._client: Optional[Client] = None
-
-    def _request_token(self) -> Token:
-        url = f"http://{settings.aion_api.host}:{settings.aion_api.port}/auth/token"
-        payload = {"client_id": self.client_id, "secret_key": self.secret}
-        response = httpx.post(url, json=payload, timeout=10)
-        response.raise_for_status()
-        token = response.json().get("access_token")
-        return Token.from_jwt(token)
-
-    def _ensure_token(self) -> None:
-        if self._token is None or self._token.expired:
-            self._token = self._request_token()
-
-    def _build_transport(self) -> WebsocketsTransport:
-        self._ensure_token()
-        url = (
-            f"ws://{settings.aion_api.host}:{settings.aion_api.port}/ws/graphql"
-            f"?token={self._token.value}"
-        )
-        return WebsocketsTransport(url=url, ping_interval=settings.aion_api.keepalive)
-
-    async def execute(self, query: str, variables: Optional[dict[str, Any]] = None) -> Any:
-        """Execute a GraphQL query using a websocket connection."""
-        transport = self._build_transport()
-        async with Client(transport=transport, fetch_schema_from_transport=False) as session:
-            return await session.execute(gql(query), variable_values=variables)
+        variables = {"request": {"model": model, "messages": list(messages), "stream": stream}}
+        async for chunk in self._gql.subscribe(CHAT_COMPLETIONS_SUBSCRIPTION, variables=variables):
+            yield chunk["chatCompletionStream"]

--- a/libs/aion-api-client/src/aion/gql/__init__.py
+++ b/libs/aion-api-client/src/aion/gql/__init__.py
@@ -1,0 +1,5 @@
+"""GraphQL utilities for interacting with the Aion API."""
+
+from .client import GqlClient
+
+__all__ = ["GqlClient"]

--- a/libs/aion-api-client/src/aion/gql/client.py
+++ b/libs/aion-api-client/src/aion/gql/client.py
@@ -1,0 +1,85 @@
+"""Low level GraphQL client for communicating with the Aion API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+import jwt
+from gql import Client, gql
+from gql.transport.websockets import WebsocketsTransport
+
+from ..api_client.settings import settings
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Token:
+    """Represents an authentication token."""
+
+    value: str
+    expires_at: datetime
+
+    @classmethod
+    def from_jwt(cls, token: str) -> "Token":
+        payload = jwt.decode(token, options={"verify_signature": False})
+        exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        return cls(value=token, expires_at=exp)
+
+    @property
+    def expired(self) -> bool:
+        return datetime.now(tz=timezone.utc) >= self.expires_at
+
+
+class GqlClient:
+    """Client for the Aion GraphQL API using websockets."""
+
+    def __init__(self) -> None:
+        self.client_id = os.getenv("AION_CLIENT_ID")
+        self.secret = os.getenv("AION_SECRET")
+        if not self.client_id or not self.secret:
+            LOGGER.error(
+                "AION_CLIENT_ID and AION_SECRET environment variables must be set"
+            )
+        self._token: Optional[Token] = None
+        self._client: Optional[Client] = None
+
+    def _request_token(self) -> Token:
+        url = f"http://{settings.aion_api.host}:{settings.aion_api.port}/auth/token"
+        payload = {"client_id": self.client_id, "secret_key": self.secret}
+        response = httpx.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+        token = response.json().get("access_token")
+        return Token.from_jwt(token)
+
+    def _ensure_token(self) -> None:
+        if self._token is None or self._token.expired:
+            self._token = self._request_token()
+
+    def _build_transport(self) -> WebsocketsTransport:
+        self._ensure_token()
+        url = (
+            f"ws://{settings.aion_api.host}:{settings.aion_api.port}/ws/graphql"
+            f"?token={self._token.value}"
+        )
+        return WebsocketsTransport(url=url, ping_interval=settings.aion_api.keepalive)
+
+    async def execute(self, query: str, variables: Optional[dict[str, Any]] = None) -> Any:
+        """Execute a GraphQL query using a websocket connection."""
+        transport = self._build_transport()
+        async with Client(transport=transport, fetch_schema_from_transport=False) as session:
+            return await session.execute(gql(query), variable_values=variables)
+
+    async def subscribe(
+        self, query: str, variables: Optional[dict[str, Any]] = None
+    ) -> Any:
+        """Subscribe to a GraphQL subscription."""
+        transport = self._build_transport()
+        async with Client(transport=transport, fetch_schema_from_transport=False) as session:
+            async for result in session.subscribe(gql(query), variable_values=variables):
+                yield result

--- a/libs/aion-api-client/tests/test_client.py
+++ b/libs/aion-api-client/tests/test_client.py
@@ -10,7 +10,8 @@ import logging
 
 import pytest
 
-from aion.api_client import AionApiClient, settings
+from aion.api_client import ApiClient, settings
+from aion.gql import GqlClient
 
 
 def test_settings_loaded() -> None:
@@ -22,8 +23,27 @@ def test_missing_env_logs_error(monkeypatch, caplog) -> None:
     caplog.set_level(logging.ERROR)
     monkeypatch.delenv("AION_CLIENT_ID", raising=False)
     monkeypatch.delenv("AION_SECRET", raising=False)
-    AionApiClient()
+    GqlClient()
     assert any(
         "AION_CLIENT_ID and AION_SECRET" in message for message in caplog.messages
     )
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_calls_gql(monkeypatch) -> None:
+    async def mock_subscribe(query: str, variables: dict | None = None):
+        assert "chatCompletionStream" in query
+        assert variables == {
+            "request": {"model": "test-model", "messages": [], "stream": True}
+        }
+        yield {"chatCompletionStream": {"done": True}}
+
+    client = ApiClient(gql_client=GqlClient())
+    monkeypatch.setattr(client._gql, "subscribe", mock_subscribe)
+
+    results = []
+    async for chunk in client.chat_completions("test-model", []):
+        results.append(chunk)
+
+    assert results == [{"done": True}]
 


### PR DESCRIPTION
## Summary
- move the low level GraphQL client into `aion.gql` as `GqlClient`
- add a new high level `ApiClient` class with `chat_completions`
- expose API and models through the package init
- update project listing in `AGENTS.md`
- adjust tests for new client behaviour

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684e15e6056083238e28574f2bb3ec3c