### PR TITLE
Add gql generation step

### DIFF
--- a/libs/aion-api-client/README.md
+++ b/libs/aion-api-client/README.md
@@ -21,3 +21,9 @@ cd libs/aion-api-client
 poetry install
 poetry run pytest
 ```
+
+To regenerate the Python classes for the GraphQL API run:
+
+```bash
+poetry run ariadne-codegen gql/schema.graphql --output src/aion/gql/generated
+```


### PR DESCRIPTION
## Summary
- add instructions for generating GraphQL code using `ariadne-codegen`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684e4306b73c8323be2b5fe47e4ffb3f