### PR TITLE
Add gql generation step

### DIFF
--- a/libs/aion-api-client/README.md
+++ b/libs/aion-api-client/README.md
@@ -21,3 +21,23 @@ cd libs/aion-api-client
 poetry install
 poetry run pytest
 ```
+
+To regenerate the Python classes for the GraphQL API run:
+
+```bash
+poetry run ariadne-codegen
+```
+
+`ariadne-codegen` reads its settings from `pyproject.toml`.
+The configuration for this project is:
+
+```toml
+[tool.ariadne-codegen]
+schema_path = "gql/schema.graphql"
+queries_path = "gql/queries.graphql"
+target_package_path = "src/aion/gql/generated"
+async_client = true
+enable_custom_operations = true
+opentelemetry_client = true
+plugins = ["ariadne_codegen.contrib.extract_operations.ExtractOperationsPlugin"]
+```

--- a/libs/aion-api-client/gql/queries.graphql
+++ b/libs/aion-api-client/gql/queries.graphql
@@ -1,0 +1,25 @@
+subscription ChatCompletions($request: ChatCompletionRequest!) {
+  chatCompletionStream(request: $request) {
+    ... on ChatCompletionStreamResponseChunk {
+      response {
+        id
+        created
+        model
+        choices {
+          index
+          delta {
+            role
+            content
+          }
+          finishReason
+        }
+      }
+    }
+    ... on ChatCompletionStreamError {
+      message
+    }
+    ... on ChatCompletionStreamComplete {
+      done
+    }
+  }
+}

--- a/libs/aion-api-client/pyproject.toml
+++ b/libs/aion-api-client/pyproject.toml
@@ -11,12 +11,23 @@ packages = [{ include = "aion", from = "src" }]
 python = "^3.11"
 dynaconf = "^3.2.5"
 gql = "^3.5.0"
-ariadne-codegen = "^0.7.0"
+ariadne-codegen = {version = "^0.7.0", extras = ["subscriptions"]}
 PyJWT = "^2.8.0"
 httpx = "^0.28.1"
+pydantic = "^2.10.6"
+websockets = "^12.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
+
+[tool.ariadne-codegen]
+schema_path = "gql/schema.graphql"
+queries_path = "gql/queries.graphql"
+target_package_path = "src/aion/gql/generated"
+async_client = true
+enable_custom_operations = true
+opentelemetry_client = true
+plugins = ["ariadne_codegen.contrib.extract_operations.ExtractOperationsPlugin"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- add instructions for generating GraphQL code using `ariadne-codegen`
- configure ariadne-codegen to output async client and extract operations
- include GraphQL subscription in `queries.graphql`
- add required dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684e4306b73c8323be2b5fe47e4ffb3f