### PR TITLE
Switch to PyYAML for configuration parsing

### DIFF
--- a/libs/aion-server-langgraph/pyproject.toml
+++ b/libs/aion-server-langgraph/pyproject.toml
@@ -21,6 +21,7 @@ SQLAlchemy = "^2.0"
 
 langgraph = "^0.3.9"
 langchain-openai = "^0.3.9"
+PyYAML = "^6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/libs/aion-server-langgraph/tests/test_yaml_loader.py
+++ b/libs/aion-server-langgraph/tests/test_yaml_loader.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import importlib.util
+import pytest
+
+pytest.importorskip("yaml")
+
+GRAPH_PATH = Path(__file__).resolve().parents[1] / "src" / "aion" / "server" / "langgraph" / "graph.py"
+
+spec = importlib.util.spec_from_file_location("graph", GRAPH_PATH)
+graph = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(graph)
+_load_simple_yaml = graph._load_simple_yaml
+
+
+def test_load_simple_yaml(tmp_path: Path) -> None:
+    content = (
+        "aion:\n"
+        "  graph:\n"
+        "    example: \"./module.py:graph\"\n"
+        "  env: \".env\"\n"
+    )
+    yaml_file = tmp_path / "aion.yaml"
+    yaml_file.write_text(content)
+
+    data = _load_simple_yaml(yaml_file)
+
+    assert data["aion"]["graph"]["example"] == "./module.py:graph"
+    assert data["aion"]["env"] == ".env"


### PR DESCRIPTION
## Summary
- use PyYAML to parse `aion.yaml`
- add PyYAML dependency to aion-server-langgraph
- test YAML loader logic

## Testing
- `pytest libs/aion-server-langgraph/tests/test_yaml_loader.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544add94688323845a8e910039c724