### PR TITLE
Fix async test setup and warnings in API client

### DIFF
--- a/libs/aion-api-client/pyproject.toml
+++ b/libs/aion-api-client/pyproject.toml
@@ -30,6 +30,9 @@ enable_custom_operations = true
 opentelemetry_client = true
 plugins = ["ariadne_codegen.contrib.extract_operations.ExtractOperationsPlugin"]
 
+[tool.pytest.ini_options]
+filterwarnings = ["ignore::DeprecationWarning"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/libs/aion-api-client/tests/conftest.py
+++ b/libs/aion-api-client/tests/conftest.py
@@ -1,0 +1,12 @@
+import warnings
+import pytest
+
+# Suppress deprecation warnings emitted by third-party dependencies which are
+# not relevant to the behaviour under test.
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Restrict AnyIO tests to the asyncio backend to avoid trio dependency."""
+    return "asyncio"

--- a/libs/aion-api-client/tests/test_aion_gql_client.py
+++ b/libs/aion-api-client/tests/test_aion_gql_client.py
@@ -20,15 +20,21 @@ os.environ.setdefault("AION_CLIENT_SECRET", "test-secret")
 from aion.api.gql.client import AionGqlClient
 
 
-@pytest.mark.asyncio
+# Using the ``anyio`` pytest plugin ensures our async tests run without requiring
+# the separate ``pytest-asyncio`` dependency.  Limit the backend to ``asyncio``
+# to avoid unnecessary trio parametrization.
+@pytest.mark.anyio("asyncio")
 async def test_chat_completion_stream_requires_initialize() -> None:
     """Calling chat_completion_stream before initialize should raise RuntimeError."""
     client = AionGqlClient()
+    stream = client.chat_completion_stream(
+        model="test-model", messages=[], stream=True
+    )
     with pytest.raises(RuntimeError):
-        await client.chat_completion_stream(model="test-model", messages=[], stream=True)
+        await anext(stream)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_initialize_twice_logs_warning(monkeypatch, caplog) -> None:
     """Repeated initialize calls log a warning and do not rebuild the client."""
     client = AionGqlClient()

--- a/libs/aion-api-client/tests/test_client.py
+++ b/libs/aion-api-client/tests/test_client.py
@@ -23,7 +23,9 @@ def test_settings_loaded() -> None:
     assert aion_api_settings.keepalive == 60
 
 
-@pytest.mark.asyncio
+# Use ``anyio``'s pytest plugin to execute async tests using the ``asyncio`` backend
+# only. This avoids unnecessary parametrization for other event loops.
+@pytest.mark.anyio("asyncio")
 async def test_chat_completion_stream_calls_gql(monkeypatch) -> None:
     async def mock_chat_completion_stream(*, model: str, messages: list, stream: bool):
         assert model == "test-model"
@@ -46,7 +48,7 @@ async def test_chat_completion_stream_calls_gql(monkeypatch) -> None:
     assert results == [{"done": True}]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_a2a_stream_calls_gql(monkeypatch) -> None:
     request = JSONRPCRequestInput(jsonrpc="2.0", method="testMethod", params=None, id=None)
 


### PR DESCRIPTION
## Summary
- run async tests with anyio
- restrict tests to asyncio backend and silence deprecation warnings
- fix async generator assertion in GraphQL client tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eaf6b50a48323902008553e664406