### PR TITLE
docs: clarify aion api client usage

### DIFF
--- a/libs/aion-api-client/README.md
+++ b/libs/aion-api-client/README.md
@@ -9,8 +9,48 @@ managed by [Dynaconf](https://www.dynaconf.com/) and loaded from
 The client authenticates with the Aion API using a `client_id` and `secret_key`.
 A JWT is obtained by POSTing these values to `/auth/token`. The returned token is
 passed to the websocket endpoint `/ws/graphql` via the `token` query parameter.
-These credentials must be supplied via the `AION_CLIENT_ID` and `AION_SECRET`
+These credentials must be supplied via the `AION_CLIENT_ID` and `AION_CLIENT_SECRET`
 environment variables. The token is refreshed automatically when it expires.
+
+## Usage
+
+To use this client in another project, first set your credentials as environment
+variables:
+
+```bash
+export AION_CLIENT_ID="your-client-id"
+export AION_CLIENT_SECRET="your-secret"
+```
+
+Connection settings such as host and port are configured in
+`aion_api_client.yaml`. You can override any of these values with additional
+`AION_`-prefixed environment variables like `AION_AION_API_HOST` or
+`AION_AION_API_PORT` if needed.
+
+Next, create and initialize the GraphQL client before making requests:
+
+```python
+import asyncio
+from aion.api.gql.client import AionGqlClient, MessageInput
+
+async def main():
+    client = AionGqlClient()  # reads credentials from environment
+    await client.initialize()
+    async for chunk in client.chat_completion_stream(
+        model="example-model",
+        messages=[MessageInput(role="user", content="Hello")],
+        stream=True,
+    ):
+        print(chunk)
+
+asyncio.run(main())
+```
+
+You can also supply credentials directly when constructing the client:
+
+```python
+client = AionGqlClient(client_id="your-client-id", client_secret="your-secret")
+```
 
 ## Development
 


### PR DESCRIPTION
## Summary
- document required `AION_CLIENT_ID` and `AION_CLIENT_SECRET` variables
- add usage section showing how to initialize and use `AionGqlClient`

## Testing
- `PYTHONPATH=libs/aion-api-client/src pytest libs/aion-api-client/tests -q` *(fails: TypeError: object async_generator can't be used in 'await' expression)*

------
https://chatgpt.com/codex/tasks/task_e_688eafb9d2788323a5036085475cd1e2