### PR TITLE
feat: allow custom JWT manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,5 +22,5 @@ This repository is a monorepo containing multiple projects located primarily und
 
 1. Libraries in packages whose names start with an underscore are provided only for context and are **not** intended to be distributed.
 2. Always use idiomatic Python and best practices.
-3. Document all code with Python docstrings in Google's style, especially at the class and method level.
+3. Document all code with detailed Python docstrings in Google's style, especially at the class and method level; avoid overly terse summaries.
 4. Create thourough unit tests for all code using pytest.

--- a/libs/aion-api-client/src/aion/api/http/__init__.py
+++ b/libs/aion-api-client/src/aion/api/http/__init__.py
@@ -1,8 +1,15 @@
+"""HTTP utilities and JWT management for the Aion API."""
+
 from .client import AionHttpClient
-from .jwt_manager import aion_jwt_manager, AionJWTManager
+from .jwt_manager import (
+    aion_jwt_manager,
+    AionJWTManager,
+    AionRefreshingJWTManager,
+)
 
 __all__ = [
     "AionHttpClient",
     "aion_jwt_manager",
     "AionJWTManager",
+    "AionRefreshingJWTManager",
 ]

--- a/libs/aion-api-client/src/aion/api/http/jwt_manager.py
+++ b/libs/aion-api-client/src/aion/api/http/jwt_manager.py
@@ -1,5 +1,10 @@
+"""JWT management utilities for Aion API clients."""
+
+from __future__ import annotations
+
 import asyncio
 import logging
+from abc import ABC, abstractmethod
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -31,8 +36,7 @@ class Token:
 
     @classmethod
     def from_jwt(cls, token: str) -> "Token":
-        """
-        Create Token instance from JWT string by decoding expiration.
+        """Create Token instance from JWT string by decoding expiration.
 
         Decodes the JWT token to extract the expiration timestamp and creates
         a Token instance with the original token string and parsed expiration time.
@@ -46,8 +50,7 @@ class Token:
 
     @property
     def expired(self) -> bool:
-        """
-        Check if the token has expired.
+        """Check if the token has expired.
 
         Compares the current UTC time with the token's expiration timestamp
         to determine if the token is no longer valid.
@@ -56,8 +59,7 @@ class Token:
 
     @property
     def expires_soon(self) -> bool:
-        """
-        Check if the token expires within 1 minute.
+        """Check if the token expires within 1 minute.
 
         Determines if the token will expire soon (within 1 minute) to allow
         for proactive token refresh before expiration.
@@ -65,39 +67,38 @@ class Token:
         return datetime.now(tz=timezone.utc) >= self.expires_at - timedelta(minutes=1)
 
 
-class AionJWTManager:
+class AionJWTManager(ABC):
     """
-    Thread-safe JWT token manager with automatic refresh capabilities.
+    Thread-safe JWT token manager without automatic refresh.
 
-    This manager handles the complete lifecycle of JWT tokens including:
-    - Automatic token refresh when expired or expiring soon
+    This manager handles the lifecycle of JWT tokens including:
     - Thread-safe access using asyncio locks
     - Caching of valid tokens to minimize API calls
-    - Integration with AionHttpClient for authentication
 
     The manager ensures that only one token refresh operation occurs at a time
-    and provides both token strings and Token objects to consumers.
+    and provides both token strings and :class:`Token` objects to consumers.
     """
-    def __init__(self):
+
+    def __init__(self) -> None:
         self._token: Optional[Token] = None
         self._lock = asyncio.Lock()
-        self._client = AionHttpClient()
 
-    async def get_token(self) -> str:
+    async def get_token(self) -> Optional[str]:
         """
         Get a valid token string, refreshing if necessary.
 
-        Returns a valid JWT token string, automatically refreshing the token
-        if it's expired, expiring soon, or doesn't exist. This method is
+        Returns the cached JWT token string, automatically calling
+        :meth:`_refresh_token` when the current token is missing, expired,
+        or expiring soon. If refresh fails, ``None`` is returned. This method is
         thread-safe and ensures only one refresh operation occurs at a time.
         """
         async with self._lock:
-            if self._should_refresh_token():
+            if self.should_refresh_token():
                 with suppress(Exception):
                     await self._refresh_token()
             return None if not self._token else self._token.value
 
-    def _should_refresh_token(self) -> bool:
+    def should_refresh_token(self) -> bool:
         """
         Check if the current token needs refresh.
 
@@ -108,44 +109,14 @@ class AionJWTManager:
         """
         if self._token is None:
             return True
-
-        # Check if token is expired or expires soon
         return self._token.expired or self._token.expires_soon
 
+    @abstractmethod
     async def _refresh_token(self) -> None:
-        """
-        Refresh the token using the HTTP client.
-
-        Performs the actual token refresh by:
-        1. Calling the authentication endpoint via HTTP client
-        2. Extracting the access token from the response
-        3. Creating a new Token object from the JWT
-        4. Updating the cached token
-        """
-        first_token = True
-        try:
-            data = await self._client.authenticate()
-
-            token_value = data.get("accessToken")
-            if not token_value:
-                raise ValueError("Access Token is missing in response.")
-
-            # Create Token object from JWT
-            self._token = Token.from_jwt(token_value)
-
-            if first_token:
-                processed_action = "fetched"
-            else:
-                processed_action = "refreshed"
-            logger.info(f"Token {processed_action} successfully, expires at: {self._token.expires_at}")
-
-        except Exception as ex:
-            logger.error(f"Token refresh failed: {ex}")
-            raise
+        """Refresh the token using custom logic."""
 
     def clear_token(self) -> None:
-        """
-        Clear the stored token from cache.
+        """Clear the stored token from cache.
 
         Removes the currently cached token, forcing a fresh authentication
         on the next token request. Useful for logout scenarios or when
@@ -154,5 +125,58 @@ class AionJWTManager:
         self._token = None
 
 
-# Global instance
-aion_jwt_manager = AionJWTManager()
+class AionRefreshingJWTManager(AionJWTManager):
+    """
+    Thread-safe JWT token manager with automatic refresh capabilities.
+
+    Integrates with :class:`AionHttpClient` for authentication.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._client = AionHttpClient()
+
+    async def get_token(self) -> Optional[str]:
+        """Return a valid token, refreshing it if necessary."""
+        async with self._lock:
+            if self.should_refresh_token():
+                with suppress(Exception):
+                    await self._refresh_token()
+            return None if not self._token else self._token.value
+
+    async def _refresh_token(self) -> None:
+        """
+        Refresh the token using the HTTP client.
+
+        Performs the actual token refresh by:
+        1. Calling the authentication endpoint via HTTP client
+        2. Extracting the access token from the response
+        3. Creating a new :class:`Token` object from the JWT
+        4. Updating the cached token
+        """
+        first_token = self._token is None
+        try:
+            data = await self._client.authenticate()
+            token_value = data.get("accessToken")
+            if not token_value:
+                raise ValueError("Access Token is missing in response.")
+
+            self._token = Token.from_jwt(token_value)
+
+            if first_token:
+                processed_action = "fetched"
+            else:
+                processed_action = "refreshed"
+            logger.info(
+                "Token %s successfully, expires at: %s",
+                processed_action,
+                self._token.expires_at,
+            )
+        except Exception as ex:  # pragma: no cover - pass through to caller
+            logger.error("Token refresh failed: %s", ex)
+            raise
+
+
+# Global instance used by the API client
+aion_jwt_manager = AionRefreshingJWTManager()
+


### PR DESCRIPTION
## Summary
- add abstract `AionJWTManager` and concrete `AionRefreshingJWTManager`
- allow `AionGqlClient` to accept a custom JWT manager instance
- expose `should_refresh_token` helper and restore refresh logging
- test custom JWT manager injection
- restore comprehensive docstrings and document docstring guidelines

## Testing
- `cd libs/aion-api-client && pytest`


------
https://chatgpt.com/codex/tasks/task_e_688edbcfafcc8323b2f57952b88bf773