### PR TITLE
feat(runtime): add AionRuntimeContextRegistry for decoupled context a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,9 @@ env/
 ENV/
 .env
 
-# Poetry
+# Dev Packages
 .venv/
+uv.lock
 poetry.lock
 
 # IDE specific files

--- a/libs/aion-api-client/src/aion/api/model_service_client.py
+++ b/libs/aion-api-client/src/aion/api/model_service_client.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
-import logging
 from typing import Mapping
-
-from aion.core.settings import api_settings
 
 from aion.api.control_plane import AION_PRINCIPAL_SELECTOR_HEADER
 from aion.api.exceptions import AionAuthenticationError
@@ -16,6 +14,8 @@ from aion.api.http.jwt_manager import (
     AionRefreshingJWTManager,
     aion_jwt_manager,
 )
+from aion.core.runtime.context import get_aion_runtime_context
+from aion.core.settings import api_settings
 
 PrincipalSelectorProvider = Callable[[], str | None]
 ModelApiKeyProvider = Callable[[], str]
@@ -32,10 +32,10 @@ class AionModelClientConfig:
     default_headers: Mapping[str, str] = field(default_factory=dict)
 
     def request_headers(
-        self,
-        existing: Mapping[str, str] | None = None,
-        *,
-        warn_on_missing: bool = True,
+            self,
+            existing: Mapping[str, str] | None = None,
+            *,
+            warn_on_missing: bool = True,
     ) -> dict[str, str]:
         """Return fresh headers for one model-service request."""
         headers = dict(self.default_headers)
@@ -74,7 +74,7 @@ def aion_model_base_url() -> str:
 
 
 def aion_model_api_key(
-    jwt_manager: AionRefreshingJWTManager | None = None,
+        jwt_manager: AionRefreshingJWTManager | None = None,
 ) -> str:
     """Return a current Aion JWT for OpenAI-compatible model clients."""
     manager = jwt_manager or aion_jwt_manager
@@ -85,14 +85,14 @@ def aion_model_api_key(
 
 
 def aion_model_api_key_provider(
-    jwt_manager: AionRefreshingJWTManager | None = None,
+        jwt_manager: AionRefreshingJWTManager | None = None,
 ) -> ModelApiKeyProvider:
     """Return a per-request API-key provider backed by the JWT manager."""
     return lambda: aion_model_api_key(jwt_manager)
 
 
 async def aion_jwt_api_key(
-    jwt_manager: AionJWTManager | None = None,
+        jwt_manager: AionJWTManager | None = None,
 ) -> str:
     """Return a short-lived JWT for OpenAI-compatible clients."""
     manager = jwt_manager or aion_jwt_manager
@@ -105,8 +105,9 @@ async def aion_jwt_api_key(
 def aion_principal_selector() -> str | None:
     """Return the current model-service principal selector, if available.
 
-    This is intentionally a placeholder until runtime-context propagation can
-    read the active Aion invocation from a ContextVar.
+    Reads the active AionRuntimeContext via AionRuntimeContextRegistry, which is
+    populated by aion-server at request entry. Returns None when called outside
+    a server context (e.g. during local development or direct script use).
 
     The returned value is used as the ``Aion-Principal-Selector`` header.
     Expected forms:
@@ -114,17 +115,17 @@ def aion_principal_selector() -> str | None:
     - Agent environment selector: ``agent-environment:<agent-environment-id>``
     - Agent identity selector: ``agent-identity:<agent-identity-id>``
     """
-    # TODO: Resolve from AionRuntimeContext once invocation context propagation
-    # is available here. The context exposes distribution/environment/identity
-    # records through distribution_extension_payload helpers.
-    return None
+    context = get_aion_runtime_context()
+    if context is None:
+        return None
+    return context.get_principal_selector()
 
 
 def aion_model_request_headers(
-    existing: Mapping[str, str] | None = None,
-    *,
-    principal_selector_provider: PrincipalSelectorProvider | None = None,
-    warn_on_missing: bool = True,
+        existing: Mapping[str, str] | None = None,
+        *,
+        principal_selector_provider: PrincipalSelectorProvider | None = None,
+        warn_on_missing: bool = True,
 ) -> dict[str, str]:
     """Return per-request headers for an Aion model-service call."""
     headers = dict(existing or {})

--- a/libs/aion-api-client/tests/test_model_service_client.py
+++ b/libs/aion-api-client/tests/test_model_service_client.py
@@ -177,3 +177,40 @@ def test_principal_selector_headers_are_optional(caplog):
 
     assert model_service_client.aion_principal_selector_headers() == {}
     assert "without principal attribution" in caplog.text
+
+
+def test_principal_selector_returns_none_when_no_provider(monkeypatch):
+    """Verify selector returns None when no runtime context provider is registered."""
+    from aion.core.runtime.context.registry import AionRuntimeContextRegistry
+    monkeypatch.setattr(AionRuntimeContextRegistry, "_provider", None)
+
+    assert model_service_client.aion_principal_selector() is None
+
+
+def test_principal_selector_returns_none_when_provider_returns_none(monkeypatch):
+    """Verify selector returns None when provider returns None (out of scope)."""
+    from aion.core.runtime.context.registry import AionRuntimeContextRegistry
+    provider = SimpleNamespace(get_current_context=lambda: None)
+    monkeypatch.setattr(AionRuntimeContextRegistry, "_provider", provider)
+
+    assert model_service_client.aion_principal_selector() is None
+
+
+def test_principal_selector_reads_environment_from_context(monkeypatch):
+    """Verify selector returns agent-environment selector from context."""
+    from aion.core.runtime.context.registry import AionRuntimeContextRegistry
+    ctx = SimpleNamespace(get_principal_selector=lambda: "agent-environment:env-42")
+    provider = SimpleNamespace(get_current_context=lambda: ctx)
+    monkeypatch.setattr(AionRuntimeContextRegistry, "_provider", provider)
+
+    assert model_service_client.aion_principal_selector() == "agent-environment:env-42"
+
+
+def test_principal_selector_reads_daemon_identity_from_context(monkeypatch):
+    """Verify selector prefers agent-identity when daemon identity is present."""
+    from aion.core.runtime.context.registry import AionRuntimeContextRegistry
+    ctx = SimpleNamespace(get_principal_selector=lambda: "agent-identity:daemon-99")
+    provider = SimpleNamespace(get_current_context=lambda: ctx)
+    monkeypatch.setattr(AionRuntimeContextRegistry, "_provider", provider)
+
+    assert model_service_client.aion_principal_selector() == "agent-identity:daemon-99"

--- a/libs/aion-core/src/aion/core/runtime/__init__.py
+++ b/libs/aion-core/src/aion/core/runtime/__init__.py
@@ -1,1 +1,6 @@
-from .context import AionRuntimeContext, AionRuntimeContextBuilder
+from .context import (
+    AionRuntimeContext,
+    AionRuntimeContextBuilder,
+    get_aion_runtime_context,
+    aget_aion_runtime_context,
+)

--- a/libs/aion-core/src/aion/core/runtime/context/__init__.py
+++ b/libs/aion-core/src/aion/core/runtime/context/__init__.py
@@ -6,6 +6,12 @@ from .models import (
     EventKind,
     NormalizedPayload,
 )
+from .registry import (
+    AionRuntimeContextProvider,
+    AionRuntimeContextRegistry,
+    get_aion_runtime_context,
+    aget_aion_runtime_context,
+)
 
 __all__ = [
     "AionExtensions",
@@ -14,4 +20,8 @@ __all__ = [
     "Event",
     "EventKind",
     "NormalizedPayload",
+    "AionRuntimeContextProvider",
+    "AionRuntimeContextRegistry",
+    "get_aion_runtime_context",
+    "aget_aion_runtime_context",
 ]

--- a/libs/aion-core/src/aion/core/runtime/context/registry.py
+++ b/libs/aion-core/src/aion/core/runtime/context/registry.py
@@ -1,0 +1,117 @@
+"""Registry for decoupled runtime-context access across aion packages."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aion.core.runtime.context.models import AionRuntimeContext
+
+
+class AionRuntimeContextProvider(ABC):
+    """Abstract backend for runtime context storage.
+
+    Each implementation must provide both a synchronous and an asynchronous
+    variant of every operation so callers can choose the appropriate form:
+
+    - Sync variants (get_current_context / set_current_context) are safe to
+      call from regular (non-async) code such as API-key callables.
+    - Async variants (aget_current_context / aset_current_context) are
+      required for providers that perform I/O (Redis, database, etc.).
+    """
+
+    @abstractmethod
+    def get_current_context(self) -> Optional["AionRuntimeContext"]:
+        """Return the active AionRuntimeContext, or None if unavailable."""
+
+    @abstractmethod
+    async def aget_current_context(self) -> Optional["AionRuntimeContext"]:
+        """Async variant of get_current_context."""
+
+    @abstractmethod
+    def set_current_context(self, context: Optional["AionRuntimeContext"]) -> None:
+        """Store context as the active AionRuntimeContext."""
+
+    @abstractmethod
+    async def aset_current_context(self, context: Optional["AionRuntimeContext"]) -> None:
+        """Async variant of set_current_context."""
+
+
+class AionRuntimeContextRegistry:
+    """Central registry for get/set of the active AionRuntimeContext.
+
+    A single AionRuntimeContextProvider is registered at server startup.
+    Both sync and async variants delegate to the registered provider.
+    """
+
+    _provider: Optional[AionRuntimeContextProvider] = None
+
+    @classmethod
+    def set_provider(cls, provider: AionRuntimeContextProvider) -> None:
+        """Register the backend. Called once at server startup."""
+        cls._provider = provider
+
+    @classmethod
+    def clear_provider(cls) -> None:
+        """Remove the registered provider (for tests)."""
+        cls._provider = None
+
+    @classmethod
+    def get_current_context(cls) -> Optional["AionRuntimeContext"]:
+        """Return the active AionRuntimeContext, or None if unavailable."""
+        if cls._provider is None:
+            return None
+        return cls._provider.get_current_context()
+
+    @classmethod
+    async def aget_current_context(cls) -> Optional["AionRuntimeContext"]:
+        """Async variant of get_current_context."""
+        if cls._provider is None:
+            return None
+        return await cls._provider.aget_current_context()
+
+    @classmethod
+    def set_current_context(cls, context: Optional["AionRuntimeContext"]) -> None:
+        """Store context via the registered provider.
+
+        Raises:
+            RuntimeError: if no provider has been registered.
+        """
+        if cls._provider is None:
+            raise RuntimeError(
+                "AionRuntimeContextRegistry has no provider registered. "
+                "Call set_provider() at server startup."
+            )
+        cls._provider.set_current_context(context)
+
+    @classmethod
+    async def aset_current_context(cls, context: Optional["AionRuntimeContext"]) -> None:
+        """Async variant of set_current_context.
+
+        Raises:
+            RuntimeError: if no provider has been registered.
+        """
+        if cls._provider is None:
+            raise RuntimeError(
+                "AionRuntimeContextRegistry has no provider registered. "
+                "Call set_provider() at server startup."
+            )
+        await cls._provider.aset_current_context(context)
+
+
+def get_aion_runtime_context() -> Optional[AionRuntimeContext]:
+    """Return the active AionRuntimeContext, or None if unavailable."""
+    return AionRuntimeContextRegistry.get_current_context()
+
+
+async def aget_aion_runtime_context() -> Optional[AionRuntimeContext]:
+    """Return the active AionRuntimeContext, or None if unavailable."""
+    return await AionRuntimeContextRegistry.aget_current_context()
+
+
+__all__ = [
+    "AionRuntimeContextProvider",
+    "AionRuntimeContextRegistry",
+    "get_aion_runtime_context",
+    "aget_aion_runtime_context",
+]

--- a/libs/aion-core/tests/runtime/test_registry.py
+++ b/libs/aion-core/tests/runtime/test_registry.py
@@ -1,0 +1,122 @@
+"""Tests for AionRuntimeContextRegistry and AionRuntimeContextProvider protocol."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from aion.core.runtime.context.registry import AionRuntimeContextRegistry
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Ensure the registry is empty before and after each test."""
+    AionRuntimeContextRegistry.clear_provider()
+    yield
+    AionRuntimeContextRegistry.clear_provider()
+
+
+def _make_provider(context=None):
+    """Return a mock satisfying AionRuntimeContextProvider (sync + async)."""
+    provider = MagicMock()
+    provider.get_current_context.return_value = context
+    provider.set_current_context.return_value = None
+    provider.aget_current_context = AsyncMock(return_value=context)
+    provider.aset_current_context = AsyncMock()
+    return provider
+
+
+class TestGetCurrentContextSync:
+    def test_returns_none_when_no_provider_registered(self):
+        assert AionRuntimeContextRegistry.get_current_context() is None
+
+    def test_delegates_to_provider(self):
+        ctx = MagicMock()
+        AionRuntimeContextRegistry.set_provider(_make_provider(ctx))
+
+        assert AionRuntimeContextRegistry.get_current_context() is ctx
+
+    def test_provider_returning_none_propagates(self):
+        AionRuntimeContextRegistry.set_provider(_make_provider(None))
+
+        assert AionRuntimeContextRegistry.get_current_context() is None
+
+
+class TestSetCurrentContextSync:
+    def test_raises_when_no_provider_registered(self):
+        with pytest.raises(RuntimeError, match="no provider registered"):
+            AionRuntimeContextRegistry.set_current_context(MagicMock())
+
+    def test_delegates_to_provider(self):
+        provider = _make_provider()
+        AionRuntimeContextRegistry.set_provider(provider)
+        ctx = MagicMock()
+
+        AionRuntimeContextRegistry.set_current_context(ctx)
+
+        provider.set_current_context.assert_called_once_with(ctx)
+
+    def test_raises_after_clear(self):
+        AionRuntimeContextRegistry.set_provider(_make_provider())
+        AionRuntimeContextRegistry.clear_provider()
+
+        with pytest.raises(RuntimeError):
+            AionRuntimeContextRegistry.set_current_context(MagicMock())
+
+
+class TestAgetCurrentContext:
+    @pytest.mark.anyio
+    async def test_returns_none_when_no_provider_registered(self):
+        assert await AionRuntimeContextRegistry.aget_current_context() is None
+
+    @pytest.mark.anyio
+    async def test_delegates_to_provider(self):
+        ctx = MagicMock()
+        AionRuntimeContextRegistry.set_provider(_make_provider(ctx))
+
+        assert await AionRuntimeContextRegistry.aget_current_context() is ctx
+
+    @pytest.mark.anyio
+    async def test_provider_returning_none_propagates(self):
+        AionRuntimeContextRegistry.set_provider(_make_provider(None))
+
+        assert await AionRuntimeContextRegistry.aget_current_context() is None
+
+
+class TestAsetCurrentContext:
+    @pytest.mark.anyio
+    async def test_raises_when_no_provider_registered(self):
+        with pytest.raises(RuntimeError, match="no provider registered"):
+            await AionRuntimeContextRegistry.aset_current_context(MagicMock())
+
+    @pytest.mark.anyio
+    async def test_delegates_to_provider(self):
+        provider = _make_provider()
+        AionRuntimeContextRegistry.set_provider(provider)
+        ctx = MagicMock()
+
+        await AionRuntimeContextRegistry.aset_current_context(ctx)
+
+        provider.aset_current_context.assert_awaited_once_with(ctx)
+
+    @pytest.mark.anyio
+    async def test_raises_after_clear(self):
+        AionRuntimeContextRegistry.set_provider(_make_provider())
+        AionRuntimeContextRegistry.clear_provider()
+
+        with pytest.raises(RuntimeError):
+            await AionRuntimeContextRegistry.aset_current_context(MagicMock())
+
+
+class TestSetProvider:
+    def test_second_set_provider_replaces_first(self):
+        ctx_a = MagicMock()
+        ctx_b = MagicMock()
+        AionRuntimeContextRegistry.set_provider(_make_provider(ctx_a))
+        AionRuntimeContextRegistry.set_provider(_make_provider(ctx_b))
+
+        assert AionRuntimeContextRegistry.get_current_context() is ctx_b
+
+    def test_clear_removes_provider(self):
+        AionRuntimeContextRegistry.set_provider(_make_provider(MagicMock()))
+        AionRuntimeContextRegistry.clear_provider()
+
+        assert AionRuntimeContextRegistry.get_current_context() is None

--- a/libs/aion-server-langgraph/src/aion/langgraph/server/execution/langgraph_executor.py
+++ b/libs/aion-server-langgraph/src/aion/langgraph/server/execution/langgraph_executor.py
@@ -13,7 +13,7 @@ from aion.server.agent.adapters import (
     ExecutorAdapter,
 )
 from aion.server.agent.exceptions import ExecutionError, StateRetrievalError
-from aion.server.agent.execution.scope import get_aion_runtime_context
+from aion.core.runtime.context.registry import AionRuntimeContextRegistry
 from .event_converter import LangGraphA2AConverter
 from .event_preprocessor import LangGraphEventPreprocessor
 from .result_handler import ExecutionResultHandler
@@ -66,7 +66,7 @@ class LangGraphExecutor(ExecutorAdapter):
             lg_inputs = LangGraphTransformer.generate_langgraph_inputs(context)
             lg_config = LangGraphTransformer.generate_langgraph_config(config)
 
-            runtime_context = get_aion_runtime_context()
+            runtime_context = await AionRuntimeContextRegistry.aget_current_context()
             stream_exec = StreamExecutor(self.compiled_graph, converter, self._preprocessor)
             events_generator = stream_exec.execute(
                 lg_inputs, lg_config,
@@ -120,7 +120,7 @@ class LangGraphExecutor(ExecutorAdapter):
 
             logger.debug(f"Resuming task")
 
-            runtime_context = get_aion_runtime_context()
+            runtime_context = await AionRuntimeContextRegistry.aget_current_context()
             stream_exec = StreamExecutor(self.compiled_graph, converter, self._preprocessor)
             events_generator = stream_exec.execute(
                 resume_command, lg_config,

--- a/libs/aion-server-langgraph/tests/execution/conftest.py
+++ b/libs/aion-server-langgraph/tests/execution/conftest.py
@@ -1,17 +1,16 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+from aion.core.runtime.context.registry import AionRuntimeContextRegistry
 
 
 @pytest.fixture(autouse=True)
 def mock_aion_runtime_context():
-    """Patch get_aion_runtime_context to return None for all executor tests.
+    """Patch AionRuntimeContextRegistry to return None for all executor tests.
 
-    LangGraphExecutor now retrieves the pre-built context from execution scope
-    (set at server level by AionAgentRequestExecutor). In unit tests, there is
-    no server-level scope, so we patch the helper to return None.
+    LangGraphExecutor retrieves the runtime context via AionRuntimeContextRegistry.
+    In unit tests there is no registered provider, so we patch the registry
+    directly to return None.
     """
-    with patch(
-        "aion.langgraph.server.execution.langgraph_executor.get_aion_runtime_context",
-        return_value=None,
-    ):
+    with patch.object(AionRuntimeContextRegistry, "aget_current_context", new=AsyncMock(return_value=None)):
         yield

--- a/libs/aion-server-langgraph/tests/execution/test_event_preprocessor.py
+++ b/libs/aion-server-langgraph/tests/execution/test_event_preprocessor.py
@@ -2,14 +2,14 @@ from unittest.mock import patch
 
 from aion.langgraph.server.execution.event_preprocessor import LangGraphEventPreprocessor
 
+_PATCH_TARGET = "aion.langgraph.server.execution.event_preprocessor.exec_scope_set_agent_framework_baggage"
+
 
 class TestLangGraphEventPreprocessor:
     def test_updates_event_sets_current_node_baggage(self):
         preprocessor = LangGraphEventPreprocessor()
 
-        with patch(
-            "aion.langgraph.server.execution.event_preprocessor.AgentExecutionScopeHelper.set_agent_framework_baggage"
-        ) as set_baggage:
+        with patch(_PATCH_TARGET) as set_baggage:
             preprocessor.process("updates", {"agent_node": {"state": 1}})
 
         set_baggage.assert_called_once_with({"langgraph.node": "agent_node"}, update=True)
@@ -17,9 +17,7 @@ class TestLangGraphEventPreprocessor:
     def test_non_updates_event_does_not_set_baggage(self):
         preprocessor = LangGraphEventPreprocessor()
 
-        with patch(
-            "aion.langgraph.server.execution.event_preprocessor.AgentExecutionScopeHelper.set_agent_framework_baggage"
-        ) as set_baggage:
+        with patch(_PATCH_TARGET) as set_baggage:
             preprocessor.process("messages", object())
 
         set_baggage.assert_not_called()
@@ -27,9 +25,7 @@ class TestLangGraphEventPreprocessor:
     def test_non_dict_update_is_ignored(self):
         preprocessor = LangGraphEventPreprocessor()
 
-        with patch(
-            "aion.langgraph.server.execution.event_preprocessor.AgentExecutionScopeHelper.set_agent_framework_baggage"
-        ) as set_baggage:
+        with patch(_PATCH_TARGET) as set_baggage:
             preprocessor.process("updates", ["node"])
 
         set_baggage.assert_not_called()
@@ -37,9 +33,7 @@ class TestLangGraphEventPreprocessor:
     def test_empty_update_is_ignored(self):
         preprocessor = LangGraphEventPreprocessor()
 
-        with patch(
-            "aion.langgraph.server.execution.event_preprocessor.AgentExecutionScopeHelper.set_agent_framework_baggage"
-        ) as set_baggage:
+        with patch(_PATCH_TARGET) as set_baggage:
             preprocessor.process("updates", {})
 
         set_baggage.assert_not_called()

--- a/libs/aion-server/src/aion/server/agent/execution/context/__init__.py
+++ b/libs/aion-server/src/aion/server/agent/execution/context/__init__.py
@@ -1,0 +1,3 @@
+from .providers import ExecutionScopeRuntimeContextProvider
+
+__all__ = ["ExecutionScopeRuntimeContextProvider"]

--- a/libs/aion-server/src/aion/server/agent/execution/request_executor.py
+++ b/libs/aion-server/src/aion/server/agent/execution/request_executor.py
@@ -14,10 +14,11 @@ from a2a.utils.errors import (
 from a2a.utils.telemetry import trace_function
 from aion.core.logging import get_logger
 from aion.core.runtime import AionRuntimeContextBuilder
+from aion.core.runtime.context.registry import AionRuntimeContextRegistry
 from aion.server.a2a.constants import TERMINAL_TASK_STATES
 from aion.server.a2a.utils import is_task_interrupted
 from aion.server.agent.aion_agent import AionAgent
-from aion.server.agent.execution.scope import set_task_id, set_aion_runtime_context
+from aion.server.agent.execution.scope import set_task_id
 from aion.server.files.a2a import A2AFileTransformer
 from typing import Optional, Tuple
 
@@ -66,7 +67,7 @@ class AionAgentRequestExecutor(AgentExecutor):
         else:
             logger.info("Resuming task")
 
-        self._setup_runtime_context(context)
+        await self._setup_runtime_context(context)
 
         try:
             event_stream = (
@@ -127,11 +128,11 @@ class AionAgentRequestExecutor(AgentExecutor):
         await task_updater.cancel()
 
     @staticmethod
-    def _setup_runtime_context(context: RequestContext) -> None:
+    async def _setup_runtime_context(context: RequestContext) -> None:
         """Build and set Aion runtime context at server level for all executors."""
         runtime_context = AionRuntimeContextBuilder.from_request_context(context)
         if runtime_context:
-            set_aion_runtime_context(runtime_context)
+            await AionRuntimeContextRegistry.aset_current_context(runtime_context)
 
     @staticmethod
     async def _get_task_for_execution(context: RequestContext) -> Tuple[Task, bool]:

--- a/libs/aion-server/src/aion/server/agent/execution/scope/__init__.py
+++ b/libs/aion-server/src/aion/server/agent/execution/scope/__init__.py
@@ -22,10 +22,7 @@ from .helper import (
     set_agent_framework_baggage,
     set_task_manager,
     get_task_manager,
-    set_aion_runtime_context,
-    get_aion_runtime_context,
 )
-
 __all__ = [
     # Types
     "RequestData",
@@ -52,6 +49,4 @@ __all__ = [
     "set_agent_framework_baggage",
     "set_task_manager",
     "get_task_manager",
-    "set_aion_runtime_context",
-    "get_aion_runtime_context",
 ]

--- a/libs/aion-server/src/aion/server/agent/execution/scope/helper.py
+++ b/libs/aion-server/src/aion/server/agent/execution/scope/helper.py
@@ -21,8 +21,6 @@ __all__ = [
     "set_agent_framework_baggage",
     "set_task_manager",
     "get_task_manager",
-    "set_aion_runtime_context",
-    "get_aion_runtime_context",
 ]
 
 _execution_scope_var: ContextVar[Optional[AgentExecutionScope]] = ContextVar(
@@ -252,39 +250,4 @@ def get_task_manager() -> Optional['AionTaskManagerProtocol']:
     return scope.runtime.task_manager
 
 
-def set_aion_runtime_context(context) -> AgentExecutionScope:
-    """Store the Aion runtime context for use throughout execution.
 
-    Makes the context (containing the parsed distribution extension payload)
-    accessible from anywhere within the execution scope, enabling proper API
-    attribution and agent identity tracking.
-
-    Args:
-        context: The AionRuntimeContext instance from aion-core.
-
-    Returns:
-        The current AgentExecutionScope.
-
-    Raises:
-        RuntimeError: If no scope is currently set. Use set_execution_scope() first.
-    """
-    scope = get_execution_scope()
-    if scope is None:
-        raise RuntimeError("No scope is currently set. Use set_execution_scope() first.")
-    scope.runtime.aion_runtime_context = context
-    return scope
-
-
-def get_aion_runtime_context():
-    """Get the Aion runtime context from execution runtime.
-
-    Returns:
-        The AionRuntimeContext instance if set, otherwise None.
-
-    Raises:
-        RuntimeError: If no scope is currently set.
-    """
-    scope = get_execution_scope()
-    if scope is None:
-        raise RuntimeError("No scope is currently set. Use set_execution_scope() first.")
-    return scope.runtime.aion_runtime_context

--- a/libs/aion-server/src/aion/server/agent/execution/scope/types.py
+++ b/libs/aion-server/src/aion/server/agent/execution/scope/types.py
@@ -7,7 +7,6 @@ from typing import Dict, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from aion.server.tasks.protocols import AionTaskManagerProtocol
-    from aion.core.runtime.context import AionRuntimeContext
 
 __all__ = [
     "RequestData",
@@ -123,12 +122,11 @@ class FrameworkScope(BaseModel):
 class ExecutionRuntime:
     """Runtime objects and context for agent execution.
 
-    Holds references to runtime components (task managers, context, stores, etc.)
+    Holds references to runtime components (task managers, stores, etc.)
     that are instantiated per agent execution. These objects are not protocol-level
     data and may not be serializable, hence stored separately from inbound/framework.
     """
     task_manager: Optional[AionTaskManagerProtocol] = None
-    aion_runtime_context: Optional['AionRuntimeContext'] = None
 
 
 @dataclass

--- a/libs/aion-server/src/aion/server/core/app/lifespan.py
+++ b/libs/aion-server/src/aion/server/core/app/lifespan.py
@@ -5,12 +5,13 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, AsyncGenerator, Optional
 
 from aion.api.http import aion_jwt_manager
-from aion.server.opentelemetry import init_tracing
+from aion.core.runtime.context.registry import AionRuntimeContextRegistry
 from aion.core.settings import api_settings
-from fastapi import FastAPI
-
 from aion.server import services as aion_services
+from aion.server.agent.execution.context import ExecutionScopeRuntimeContextProvider
 from aion.server.core.platform import AionWebSocketManager, WebsocketTransportFactory
+from aion.server.opentelemetry import init_tracing
+from fastapi import FastAPI
 
 if TYPE_CHECKING:
     from aion.server.core.app import AppFactory
@@ -51,6 +52,10 @@ class AppLifespan:
 
     async def startup(self):
         """Handle application startup events."""
+        # Register runtime context provider so aion-api-client can resolve
+        # the active principal selector without depending on aion-server.
+        AionRuntimeContextRegistry.set_provider(ExecutionScopeRuntimeContextProvider())
+
         # SETUP OPEN-TELEMETRY
         init_tracing()
         asyncio.create_task(self._start_ws_connection())

--- a/libs/aion-server/tests/agent/test_execution_scope_provider.py
+++ b/libs/aion-server/tests/agent/test_execution_scope_provider.py
@@ -1,0 +1,114 @@
+"""Tests for ExecutionScopeRuntimeContextProvider."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from aion.server.agent.execution.context.providers import ExecutionScopeRuntimeContextProvider
+
+
+@pytest.fixture(autouse=True)
+def reset_context_var():
+    """Reset the module-level ContextVar before and after each test."""
+    _provider = ExecutionScopeRuntimeContextProvider()
+    _provider.set_current_context(None)
+    yield
+    _provider.set_current_context(None)
+
+
+class TestGetCurrentContextSync:
+    def test_returns_none_by_default(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        assert provider.get_current_context() is None
+
+    def test_returns_context_when_set(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        ctx = MagicMock()
+        provider.set_current_context(ctx)
+
+        assert provider.get_current_context() is ctx
+
+    def test_returns_none_after_set_none(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        provider.set_current_context(MagicMock())
+        provider.set_current_context(None)
+
+        assert provider.get_current_context() is None
+
+
+class TestSetCurrentContextSync:
+    def test_stores_context(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        ctx = MagicMock()
+        provider.set_current_context(ctx)
+
+        assert provider.get_current_context() is ctx
+
+    def test_overwrite_replaces_previous(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        ctx1, ctx2 = MagicMock(), MagicMock()
+        provider.set_current_context(ctx1)
+        provider.set_current_context(ctx2)
+
+        assert provider.get_current_context() is ctx2
+
+
+class TestAgetCurrentContext:
+    @pytest.mark.anyio
+    async def test_returns_none_by_default(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        assert await provider.aget_current_context() is None
+
+    @pytest.mark.anyio
+    async def test_returns_context_when_set(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        ctx = MagicMock()
+        await provider.aset_current_context(ctx)
+
+        assert await provider.aget_current_context() is ctx
+
+    @pytest.mark.anyio
+    async def test_returns_none_after_set_none(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        await provider.aset_current_context(MagicMock())
+        await provider.aset_current_context(None)
+
+        assert await provider.aget_current_context() is None
+
+
+class TestAsetCurrentContext:
+    @pytest.mark.anyio
+    async def test_stores_context(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        ctx = MagicMock()
+        await provider.aset_current_context(ctx)
+
+        assert await provider.aget_current_context() is ctx
+
+    @pytest.mark.anyio
+    async def test_overwrite_replaces_previous(self):
+        provider = ExecutionScopeRuntimeContextProvider()
+        ctx1, ctx2 = MagicMock(), MagicMock()
+        await provider.aset_current_context(ctx1)
+        await provider.aset_current_context(ctx2)
+
+        assert await provider.aget_current_context() is ctx2
+
+
+class TestSyncAsyncConsistency:
+    @pytest.mark.anyio
+    async def test_sync_set_visible_via_async_get(self):
+        """Verify sync set is immediately visible via async get (same ContextVar)."""
+        provider = ExecutionScopeRuntimeContextProvider()
+        ctx = MagicMock()
+        provider.set_current_context(ctx)
+
+        assert await provider.aget_current_context() is ctx
+
+    @pytest.mark.anyio
+    async def test_async_set_visible_via_sync_get(self):
+        """Verify async set is immediately visible via sync get (same ContextVar)."""
+        provider = ExecutionScopeRuntimeContextProvider()
+        ctx = MagicMock()
+        await provider.aset_current_context(ctx)
+
+        assert provider.get_current_context() is ctx

--- a/libs/aion-server/tests/unit/agent/test_request_executor.py
+++ b/libs/aion-server/tests/unit/agent/test_request_executor.py
@@ -6,7 +6,7 @@ from a2a.types import TaskState
 from a2a.utils.errors import TaskNotCancelableError, TaskNotFoundError, UnsupportedOperationError
 
 from aion.server.agent.execution import AionAgentRequestExecutor
-from aion.server.agent.execution.scope import init_execution_scope, get_aion_runtime_context
+from aion.server.agent.execution.scope import init_execution_scope
 
 
 def _make_task(state: TaskState = TaskState.TASK_STATE_WORKING):
@@ -75,7 +75,8 @@ class TestExecuteRuntimeContext:
             mock_context = MagicMock()
             MockBuilder.from_request_context.return_value = mock_context
 
-            with patch("aion.server.agent.execution.request_executor.set_aion_runtime_context") as mock_set:
+            with patch("aion.server.agent.execution.request_executor.AionRuntimeContextRegistry") as MockRegistry:
+                MockRegistry.aset_current_context = AsyncMock()
                 with patch("aion.server.agent.execution.request_executor.AionEventPipeline"):
                     # Mock _get_task_for_execution to return our task
                     with patch.object(executor, "_get_task_for_execution", new=AsyncMock(return_value=(task, True))):
@@ -89,8 +90,8 @@ class TestExecuteRuntimeContext:
                         # Verify context was built from request context
                         MockBuilder.from_request_context.assert_called_once_with(ctx)
 
-                        # Verify context was set in scope
-                        mock_set.assert_called_once_with(mock_context)
+                        # Verify context was set via registry
+                        MockRegistry.aset_current_context.assert_awaited_once_with(mock_context)
 
     @pytest.mark.anyio
     async def test_execute_handles_missing_runtime_context(self):
@@ -106,7 +107,8 @@ class TestExecuteRuntimeContext:
             # Simulate no context available (e.g., graph without a2a_inbox)
             MockBuilder.from_request_context.return_value = None
 
-            with patch("aion.server.agent.execution.request_executor.set_aion_runtime_context") as mock_set:
+            with patch("aion.server.agent.execution.request_executor.AionRuntimeContextRegistry") as MockRegistry:
+                MockRegistry.aset_current_context = AsyncMock()
                 with patch("aion.server.agent.execution.request_executor.AionEventPipeline"):
                     with patch.object(executor, "_get_task_for_execution", new=AsyncMock(return_value=(task, True))):
                         async def empty_stream(*args, **kwargs):
@@ -119,8 +121,8 @@ class TestExecuteRuntimeContext:
                         # Verify builder was called
                         MockBuilder.from_request_context.assert_called_once_with(ctx)
 
-                        # Verify set_aion_runtime_context was NOT called when context is None
-                        mock_set.assert_not_called()
+                        # Verify set_current_context was NOT called when context is None
+                        MockRegistry.aset_current_context.assert_not_awaited()
 
 
 class TestCancel:


### PR DESCRIPTION
…ccess

Replace execution-scope helpers with a provider-based registry backed by a ContextVar. Any package can now access AionRuntimeContext via `get_aion_runtime_context()` without depending on aion-server internals.