### PR TITLE
feat(runtime-context): add RequestScopeRuntimeContextProvider

### DIFF
--- a/libs/aion-api-client/src/aion/api/model_service_client.py
+++ b/libs/aion-api-client/src/aion/api/model_service_client.py
@@ -51,6 +51,7 @@ class AionModelClientConfig:
             "api_key": self.api_key,
         }
         headers = self.request_headers()
+        headers.setdefault("Accept", "application/json, text/event-stream")
         if headers:
             kwargs["default_headers"] = headers
         return kwargs

--- a/libs/aion-server/src/aion/server/agent/execution/context/__init__.py
+++ b/libs/aion-server/src/aion/server/agent/execution/context/__init__.py
@@ -1,3 +1,3 @@
-from .providers import ExecutionScopeRuntimeContextProvider
+from .providers import RequestScopeRuntimeContextProvider
 
-__all__ = ["ExecutionScopeRuntimeContextProvider"]
+__all__ = ["RequestScopeRuntimeContextProvider"]

--- a/libs/aion-server/src/aion/server/agent/execution/context/providers.py
+++ b/libs/aion-server/src/aion/server/agent/execution/context/providers.py
@@ -1,0 +1,45 @@
+"""AionRuntimeContextProvider implementation backed by a ContextVar."""
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Optional, TYPE_CHECKING
+
+from aion.core.runtime.context.registry import AionRuntimeContextProvider
+
+if TYPE_CHECKING:
+    from aion.core.runtime.context.models import AionRuntimeContext
+
+_context_var: ContextVar[Optional["AionRuntimeContext"]] = ContextVar(
+    "aion_runtime_context", default=None
+)
+
+
+class RequestScopeRuntimeContextProvider(AionRuntimeContextProvider):
+    """Reads/writes AionRuntimeContext via a ContextVar.
+
+    Each async task inherits the ContextVar value from its parent and can
+    mutate it independently — concurrent executions are fully isolated.
+
+    Both sync and async variants are safe to call: ContextVar operations are
+    inherently synchronous, so the async wrappers simply delegate to the
+    sync implementation.
+    """
+
+    def get_current_context(self) -> Optional["AionRuntimeContext"]:
+        """Return the active AionRuntimeContext, or None if not set."""
+        return _context_var.get()
+
+    def set_current_context(self, context: Optional["AionRuntimeContext"]) -> None:
+        """Store context for the current async task."""
+        _context_var.set(context)
+
+    async def aget_current_context(self) -> Optional["AionRuntimeContext"]:
+        """Async variant of get_current_context."""
+        return _context_var.get()
+
+    async def aset_current_context(self, context: Optional["AionRuntimeContext"]) -> None:
+        """Async variant of set_current_context."""
+        _context_var.set(context)
+
+
+__all__ = ["RequestScopeRuntimeContextProvider"]

--- a/libs/aion-server/src/aion/server/core/app/lifespan.py
+++ b/libs/aion-server/src/aion/server/core/app/lifespan.py
@@ -8,7 +8,7 @@ from aion.api.http import aion_jwt_manager
 from aion.core.runtime.context.registry import AionRuntimeContextRegistry
 from aion.core.settings import api_settings
 from aion.server import services as aion_services
-from aion.server.agent.execution.context import ExecutionScopeRuntimeContextProvider
+from aion.server.agent.execution.context import RequestScopeRuntimeContextProvider
 from aion.server.core.platform import AionWebSocketManager, WebsocketTransportFactory
 from aion.server.opentelemetry import init_tracing
 from fastapi import FastAPI
@@ -54,7 +54,7 @@ class AppLifespan:
         """Handle application startup events."""
         # Register runtime context provider so aion-api-client can resolve
         # the active principal selector without depending on aion-server.
-        AionRuntimeContextRegistry.set_provider(ExecutionScopeRuntimeContextProvider())
+        AionRuntimeContextRegistry.set_provider(RequestScopeRuntimeContextProvider())
 
         # SETUP OPEN-TELEMETRY
         init_tracing()

--- a/libs/aion-server/tests/agent/test_execution_scope_provider.py
+++ b/libs/aion-server/tests/agent/test_execution_scope_provider.py
@@ -1,15 +1,15 @@
-"""Tests for ExecutionScopeRuntimeContextProvider."""
+"""Tests for RequestScopeRuntimeContextProvider."""
 
 import pytest
 from unittest.mock import MagicMock
 
-from aion.server.agent.execution.context.providers import ExecutionScopeRuntimeContextProvider
+from aion.server.agent.execution.context.providers import RequestScopeRuntimeContextProvider
 
 
 @pytest.fixture(autouse=True)
 def reset_context_var():
     """Reset the module-level ContextVar before and after each test."""
-    _provider = ExecutionScopeRuntimeContextProvider()
+    _provider = RequestScopeRuntimeContextProvider()
     _provider.set_current_context(None)
     yield
     _provider.set_current_context(None)
@@ -17,18 +17,18 @@ def reset_context_var():
 
 class TestGetCurrentContextSync:
     def test_returns_none_by_default(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         assert provider.get_current_context() is None
 
     def test_returns_context_when_set(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         ctx = MagicMock()
         provider.set_current_context(ctx)
 
         assert provider.get_current_context() is ctx
 
     def test_returns_none_after_set_none(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         provider.set_current_context(MagicMock())
         provider.set_current_context(None)
 
@@ -37,14 +37,14 @@ class TestGetCurrentContextSync:
 
 class TestSetCurrentContextSync:
     def test_stores_context(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         ctx = MagicMock()
         provider.set_current_context(ctx)
 
         assert provider.get_current_context() is ctx
 
     def test_overwrite_replaces_previous(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         ctx1, ctx2 = MagicMock(), MagicMock()
         provider.set_current_context(ctx1)
         provider.set_current_context(ctx2)
@@ -55,12 +55,12 @@ class TestSetCurrentContextSync:
 class TestAgetCurrentContext:
     @pytest.mark.anyio
     async def test_returns_none_by_default(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         assert await provider.aget_current_context() is None
 
     @pytest.mark.anyio
     async def test_returns_context_when_set(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         ctx = MagicMock()
         await provider.aset_current_context(ctx)
 
@@ -68,7 +68,7 @@ class TestAgetCurrentContext:
 
     @pytest.mark.anyio
     async def test_returns_none_after_set_none(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         await provider.aset_current_context(MagicMock())
         await provider.aset_current_context(None)
 
@@ -78,7 +78,7 @@ class TestAgetCurrentContext:
 class TestAsetCurrentContext:
     @pytest.mark.anyio
     async def test_stores_context(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         ctx = MagicMock()
         await provider.aset_current_context(ctx)
 
@@ -86,7 +86,7 @@ class TestAsetCurrentContext:
 
     @pytest.mark.anyio
     async def test_overwrite_replaces_previous(self):
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         ctx1, ctx2 = MagicMock(), MagicMock()
         await provider.aset_current_context(ctx1)
         await provider.aset_current_context(ctx2)
@@ -98,7 +98,7 @@ class TestSyncAsyncConsistency:
     @pytest.mark.anyio
     async def test_sync_set_visible_via_async_get(self):
         """Verify sync set is immediately visible via async get (same ContextVar)."""
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         ctx = MagicMock()
         provider.set_current_context(ctx)
 
@@ -107,7 +107,7 @@ class TestSyncAsyncConsistency:
     @pytest.mark.anyio
     async def test_async_set_visible_via_sync_get(self):
         """Verify async set is immediately visible via sync get (same ContextVar)."""
-        provider = ExecutionScopeRuntimeContextProvider()
+        provider = RequestScopeRuntimeContextProvider()
         ctx = MagicMock()
         await provider.aset_current_context(ctx)
 


### PR DESCRIPTION
Implement ContextVar-backed provider for task-isolated AionRuntimeContext management with sync/async support. Also set Accept header default for streaming responses in model service client.