### PR TITLE
test: standardize pytest setup across all libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help deps-install-dev deps-install deps-lock deps-lock-regenerate deps-sync deps-set-branch deps-set-local deps-set-local-revert
+.PHONY: help tests deps-install-dev deps-install deps-lock deps-lock-regenerate deps-sync deps-set-branch deps-set-local deps-set-local-revert
 
 help: ## Show available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+tests: ## Run tests for all libs
+	./scripts/tests.py
 
 deps-install-dev: ## Install local dependencies in editable mode for development
 	./scripts/deps/install-dev.py

--- a/libs/aion-api-client/pyproject.toml
+++ b/libs/aion-api-client/pyproject.toml
@@ -19,6 +19,7 @@ aion-core = { git = "https://github.com/Terminal-Research/aion-python-sdk", bran
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"
+pytest-asyncio = ">=0.24"
 
 [tool.ariadne-codegen]
 schema_path = "gql/schema.graphql"
@@ -31,6 +32,7 @@ opentelemetry_client = true
 plugins = ["ariadne_codegen.contrib.extract_operations.ExtractOperationsPlugin"]
 
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 filterwarnings = ["ignore::DeprecationWarning"]
 
 [build-system]

--- a/libs/aion-authoring-adk/pyproject.toml
+++ b/libs/aion-authoring-adk/pyproject.toml
@@ -14,8 +14,10 @@ aion-mcp = { git = "https://github.com/Terminal-Research/aion-python-sdk", branc
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"
+pytest-asyncio = ">=0.24"
 
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 testpaths = ["tests"]
 
 [build-system]

--- a/libs/aion-authoring-adk/tests/test_thread_routing.py
+++ b/libs/aion-authoring-adk/tests/test_thread_routing.py
@@ -22,8 +22,8 @@ def make_thread():
     from aion.adk.authoring.invocation.thread import Thread
     return Thread(
         context=MagicMock(),
-        id="C123",
-        parent_id=None,
+        context_id="C123",
+        parent_context_id=None,
         network="Slack",
         default_reply_target="C123",
     )

--- a/libs/aion-authoring-langgraph/tests/test_mcp_tools.py
+++ b/libs/aion-authoring-langgraph/tests/test_mcp_tools.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import pytest
 
 from aion.api.control_plane import (
     AION_PRINCIPAL_SELECTOR_HEADER,
@@ -124,7 +123,6 @@ def test_langgraph_mcp_server_config_sync_resolves_runtime_references() -> None:
     }
 
 
-@pytest.mark.asyncio
 async def test_load_aion_mcp_tools_uses_client_factory() -> None:
     """Verify LangGraph tool loading delegates to MultiServerMCPClient shape."""
     captured = {}

--- a/libs/aion-core/tests/test_db_protocol.py
+++ b/libs/aion-core/tests/test_db_protocol.py
@@ -76,14 +76,12 @@ class TestIsInitialized:
         mgr = _ConcreteDbManager(initialized=False)
         assert mgr.is_initialized is False
 
-    @pytest.mark.asyncio
     async def test_true_after_initialize(self):
         """Verify that true after initialize."""
         mgr = _ConcreteDbManager()
         await mgr.initialize("postgresql://localhost/test")
         assert mgr.is_initialized is True
 
-    @pytest.mark.asyncio
     async def test_false_after_close(self):
         """Verify that false after close."""
         mgr = _ConcreteDbManager(initialized=True)
@@ -92,21 +90,18 @@ class TestIsInitialized:
 
 
 class TestLifecycle:
-    @pytest.mark.asyncio
     async def test_initialize_stores_dsn(self):
         """Verify that initialize stores dsn."""
         mgr = _ConcreteDbManager()
         await mgr.initialize("postgresql://host/mydb")
         assert mgr.get_dsn() == "postgresql://host/mydb"
 
-    @pytest.mark.asyncio
     async def test_close_is_idempotent(self):
         """Verify that close is idempotent."""
         mgr = _ConcreteDbManager(initialized=True)
         await mgr.close()
         await mgr.close()  # second call should not raise
 
-    @pytest.mark.asyncio
     async def test_reinitialize_after_close(self):
         """Verify that reinitialize after close."""
         mgr = _ConcreteDbManager()
@@ -144,14 +139,12 @@ class TestUninitializedGuard:
 
 
 class TestGetSession:
-    @pytest.mark.asyncio
     async def test_get_session_yields_session(self):
         """Verify that get session yields session."""
         mgr = _ConcreteDbManager(initialized=True)
         async with mgr.get_session() as session:
             assert session is not None
 
-    @pytest.mark.asyncio
     async def test_get_session_usable_multiple_times(self):
         """Verify that get session usable multiple times."""
         mgr = _ConcreteDbManager(initialized=True)
@@ -166,7 +159,6 @@ class TestGetDsn:
         mgr = _ConcreteDbManager()
         assert isinstance(mgr.get_dsn(), str)
 
-    @pytest.mark.asyncio
     async def test_reflects_initialized_dsn(self):
         """Verify that reflects initialized dsn."""
         mgr = _ConcreteDbManager()

--- a/libs/aion-db/pyproject.toml
+++ b/libs/aion-db/pyproject.toml
@@ -15,6 +15,14 @@ psycopg = { version = ">=3.1.12,<4.0.0", extras = ["binary", "pool"] }
 greenlet = ">=3.0.3,<4.0.0"
 aion-core = { git = "https://github.com/Terminal-Research/aion-python-sdk", branch = "main", subdirectory = "libs/aion-core" }
 
+[tool.poetry.group.dev.dependencies]
+pytest = ">=8.0.0"
+pytest-asyncio = ">=0.24"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/libs/aion-mcp/pyproject.toml
+++ b/libs/aion-mcp/pyproject.toml
@@ -14,6 +14,10 @@ PyYAML = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"
+pytest-asyncio = ">=0.24"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["poetry-core"]

--- a/libs/aion-sdk/pyproject.toml
+++ b/libs/aion-sdk/pyproject.toml
@@ -31,6 +31,10 @@ all = [
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"
+pytest-asyncio = ">=0.24"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["poetry-core"]

--- a/libs/aion-sdk/tests/conftest.py
+++ b/libs/aion-sdk/tests/conftest.py
@@ -22,7 +22,7 @@ def _install_test_stubs() -> None:
     environment. These stubs keep the tests focused on ``aion-cli`` behavior.
     """
 
-    import click
+    import asyncclick as click
 
     sys.modules.setdefault("asyncclick", click)
 

--- a/libs/aion-sdk/tests/test_cli.py
+++ b/libs/aion-sdk/tests/test_cli.py
@@ -6,34 +6,34 @@ import importlib
 import asyncio
 from threading import Event, Thread
 
-from click.testing import CliRunner
+from asyncclick.testing import CliRunner
 
 from aion.cli.cli import __version__, cli
 from aion.cli.services.chat import BinaryResolutionError
 
 
-def test_version() -> None:
+async def test_version() -> None:
     """Verify that the version flag renders the package version."""
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["--version"])
+    result = await runner.invoke(cli, ["--version"])
 
     assert result.exit_code == 0
     assert __version__ in result.output
 
 
-def test_help_lists_chat_command() -> None:
+async def test_help_lists_chat_command() -> None:
     """Ensure the help output advertises the experimental chat command."""
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["--help"])
+    result = await runner.invoke(cli, ["--help"])
 
     assert result.exit_code == 0
     assert "chat" in result.output
     assert "logs" in result.output
 
 
-def test_chat_launches_ui(monkeypatch) -> None:
+async def test_chat_launches_ui(monkeypatch) -> None:
     """Ensure ``aion chat`` forwards CLI flags into launch options."""
     runner = CliRunner()
     chat_module = importlib.import_module("aion.cli.commands.chat")
@@ -45,7 +45,7 @@ def test_chat_launches_ui(monkeypatch) -> None:
 
     monkeypatch.setattr(chat_module, "launch_chat", fake_launch)
 
-    result = runner.invoke(
+    result = await runner.invoke(
         cli,
         [
             "chat",
@@ -73,7 +73,7 @@ def test_chat_launches_ui(monkeypatch) -> None:
     assert options.push_receiver == "http://localhost:5050"
 
 
-def test_chat_reports_missing_artifact(monkeypatch) -> None:
+async def test_chat_reports_missing_artifact(monkeypatch) -> None:
     """Ensure binary resolution failures surface as Click exceptions."""
     runner = CliRunner()
     chat_module = importlib.import_module("aion.cli.commands.chat")
@@ -83,13 +83,13 @@ def test_chat_reports_missing_artifact(monkeypatch) -> None:
 
     monkeypatch.setattr(chat_module, "launch_chat", fake_launch)
 
-    result = runner.invoke(cli, ["chat", "--url", "http://localhost:8000"])
+    result = await runner.invoke(cli, ["chat", "--url", "http://localhost:8000"])
 
     assert result.exit_code != 0
     assert "missing chat artifact" in result.output
 
 
-def test_chat_defaults_to_local_proxy(monkeypatch) -> None:
+async def test_chat_defaults_to_local_proxy(monkeypatch) -> None:
     """Ensure ``aion chat`` lets the UI resolve the selected environment."""
     runner = CliRunner()
     chat_module = importlib.import_module("aion.cli.commands.chat")
@@ -101,14 +101,14 @@ def test_chat_defaults_to_local_proxy(monkeypatch) -> None:
 
     monkeypatch.setattr(chat_module, "launch_chat", fake_launch)
 
-    result = runner.invoke(cli, ["chat"])
+    result = await runner.invoke(cli, ["chat"])
 
     assert result.exit_code == 0
     options = called["options"]
     assert options.endpoint is None
 
 
-def test_chat_run_launches_headless_ui(monkeypatch) -> None:
+async def test_chat_run_launches_headless_ui(monkeypatch) -> None:
     """Ensure ``aion chat run`` forwards one-shot request options."""
     runner = CliRunner()
     chat_module = importlib.import_module("aion.cli.commands.chat")
@@ -120,7 +120,7 @@ def test_chat_run_launches_headless_ui(monkeypatch) -> None:
 
     monkeypatch.setattr(chat_module, "launch_chat_run", fake_launch)
 
-    result = runner.invoke(
+    result = await runner.invoke(
         cli,
         [
             "chat",
@@ -144,11 +144,11 @@ def test_chat_run_launches_headless_ui(monkeypatch) -> None:
     assert options.message == "hello there"
 
 
-def test_chat_run_help_describes_headless_usage() -> None:
+async def test_chat_run_help_describes_headless_usage() -> None:
     """Ensure ``aion chat run --help`` includes headless usage guidance."""
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["chat", "run", "--help"])
+    result = await runner.invoke(cli, ["chat", "run", "--help"])
 
     assert result.exit_code == 0
     assert "Agent selection:" in result.output
@@ -156,7 +156,7 @@ def test_chat_run_help_describes_headless_usage() -> None:
     assert "aion chat run --agent @team-agent" in result.output
 
 
-def test_logs_tails_authenticated_version_logs(monkeypatch) -> None:
+async def test_logs_tails_authenticated_version_logs(monkeypatch) -> None:
     """Ensure ``aion logs`` streams formatted version log events."""
     runner = CliRunner()
     logs_service = importlib.import_module("aion.cli.services.logs")
@@ -191,7 +191,7 @@ def test_logs_tails_authenticated_version_logs(monkeypatch) -> None:
 
     monkeypatch.setattr(logs_service, "AionGqlContextClient", FakeContextClient)
 
-    result = runner.invoke(
+    result = await runner.invoke(
         cli, ["logs", "--since", "2026-05-14T15:00:00Z"]
     )
 
@@ -205,7 +205,7 @@ def test_logs_tails_authenticated_version_logs(monkeypatch) -> None:
     assert "requestId=req-1" not in result.output
 
 
-def test_logs_can_include_properties(monkeypatch) -> None:
+async def test_logs_can_include_properties(monkeypatch) -> None:
     """Ensure structured properties are opt-in for log output."""
     runner = CliRunner()
     logs_service = importlib.import_module("aion.cli.services.logs")
@@ -235,7 +235,7 @@ def test_logs_can_include_properties(monkeypatch) -> None:
 
     monkeypatch.setattr(logs_service, "AionGqlContextClient", FakeContextClient)
 
-    result = runner.invoke(
+    result = await runner.invoke(
         cli,
         [
             "logs",
@@ -279,21 +279,21 @@ def test_logs_worker_cancellation_stops_subscription_task() -> None:
     assert errors == []
 
 
-def test_login_is_not_a_python_cli_command() -> None:
+async def test_login_is_not_a_python_cli_command() -> None:
     """Ensure chat UI login remains scoped to the npm CLI and composer."""
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["login"])
+    result = await runner.invoke(cli, ["login"])
 
     assert result.exit_code != 0
     assert "No such command" in result.output
 
 
-def test_environment_is_not_a_python_cli_command() -> None:
+async def test_environment_is_not_a_python_cli_command() -> None:
     """Ensure chat UI environment switching remains scoped to npm and composer."""
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["env", "development"])
+    result = await runner.invoke(cli, ["env", "development"])
 
     assert result.exit_code != 0
     assert "No such command" in result.output

--- a/libs/aion-server/tests/agent/test_plugin_protocols.py
+++ b/libs/aion-server/tests/agent/test_plugin_protocols.py
@@ -74,7 +74,6 @@ class TestBasePluginProtocolName:
 
 
 class TestBasePluginProtocolInitialize:
-    @pytest.mark.asyncio
     async def test_initialize_receives_db_manager(self):
         """initialize is called with the db_manager and stores it."""
         plugin = _ConcretePlugin()
@@ -82,7 +81,6 @@ class TestBasePluginProtocolInitialize:
         await plugin.initialize(db_manager)
         assert plugin._initialized_with is db_manager
 
-    @pytest.mark.asyncio
     async def test_initialize_accepts_file_upload_manager(self):
         """initialize accepts an optional file_upload_manager without error."""
         plugin = _ConcretePlugin()
@@ -91,7 +89,6 @@ class TestBasePluginProtocolInitialize:
         await plugin.initialize(db, file_upload_manager=file_mgr)
         assert plugin._initialized_with is db
 
-    @pytest.mark.asyncio
     async def test_initialize_accepts_extra_deps(self):
         """initialize forwards extra keyword dependencies to the implementation."""
         class _DepPlugin(BasePluginProtocol):
@@ -105,13 +102,11 @@ class TestBasePluginProtocolInitialize:
 
 
 class TestBasePluginProtocolTeardown:
-    @pytest.mark.asyncio
     async def test_teardown_default_does_not_raise(self):
         """Default teardown() completes without raising an exception."""
         plugin = _ConcretePlugin()
         await plugin.teardown()  # should complete without error
 
-    @pytest.mark.asyncio
     async def test_teardown_can_be_overridden(self):
         """A subclass can override teardown() with custom cleanup logic."""
         class _WithTeardown(BasePluginProtocol):
@@ -124,7 +119,6 @@ class TestBasePluginProtocolTeardown:
         await plugin.teardown()
         assert _WithTeardown.torn_down is True
 
-    @pytest.mark.asyncio
     async def test_teardown_is_idempotent(self):
         """teardown() can be called multiple times without raising."""
         plugin = _ConcretePlugin()
@@ -133,14 +127,12 @@ class TestBasePluginProtocolTeardown:
 
 
 class TestBasePluginProtocolHealthCheck:
-    @pytest.mark.asyncio
     async def test_default_health_check_returns_true(self):
         """Default health_check() returns True."""
         plugin = _ConcretePlugin()
         result = await plugin.health_check()
         assert result is True
 
-    @pytest.mark.asyncio
     async def test_health_check_can_be_overridden_to_false(self):
         """A subclass can override health_check() to return False when unhealthy."""
         class _Unhealthy(BasePluginProtocol):
@@ -190,7 +182,6 @@ class TestAgentPluginProtocolGetAdapter:
 
 
 class TestAgentPluginProtocolConfigureApp:
-    @pytest.mark.asyncio
     async def test_configure_app_default_does_not_raise(self):
         """Default configure_app() completes without raising an exception."""
         plugin = _ConcreteAgentPlugin()
@@ -198,7 +189,6 @@ class TestAgentPluginProtocolConfigureApp:
         agent = MagicMock()
         await plugin.configure_app(app, agent)  # default impl — should not raise
 
-    @pytest.mark.asyncio
     async def test_configure_app_can_be_overridden(self):
         """A subclass can override configure_app() to perform custom app configuration."""
         class _Configuring(AgentPluginProtocol):
@@ -214,13 +204,11 @@ class TestAgentPluginProtocolConfigureApp:
 
 
 class TestAgentPluginProtocolInheritance:
-    @pytest.mark.asyncio
     async def test_inherits_default_teardown(self):
         """AgentPluginProtocol inherits the default teardown() that does not raise."""
         plugin = _ConcreteAgentPlugin()
         await plugin.teardown()  # should not raise
 
-    @pytest.mark.asyncio
     async def test_inherits_default_health_check(self):
         """AgentPluginProtocol inherits the default health_check() returning True."""
         plugin = _ConcreteAgentPlugin()

--- a/libs/aion-server/tests/agent/test_request_context_builder.py
+++ b/libs/aion-server/tests/agent/test_request_context_builder.py
@@ -23,14 +23,12 @@ class TestFindInterruptedTask:
     def builder(self):
         return AionRequestContextBuilder(task_store=_make_store(None))
 
-    @pytest.mark.asyncio
     async def test_returns_none_when_no_task_exists(self):
         """No prior task for the context — should return None, not raise TypeError."""
         builder = AionRequestContextBuilder(task_store=_make_store(None))
         result = await builder._find_interrupted_task("ctx-new")
         assert result is None
 
-    @pytest.mark.asyncio
     async def test_returns_none_when_task_not_interrupted(self):
         """Task exists but is completed — should return None."""
         store = _make_store(_make_task(TaskState.TASK_STATE_COMPLETED))
@@ -38,7 +36,6 @@ class TestFindInterruptedTask:
         result = await builder._find_interrupted_task("ctx-1")
         assert result is None
 
-    @pytest.mark.asyncio
     async def test_returns_task_when_interrupted(self):
         """Task exists and is interrupted — should return it."""
         task = _make_task(TaskState.TASK_STATE_INPUT_REQUIRED)
@@ -47,7 +44,6 @@ class TestFindInterruptedTask:
         result = await builder._find_interrupted_task("ctx-1")
         assert result is task
 
-    @pytest.mark.asyncio
     async def test_returns_none_when_no_task_store(self):
         """No task store configured — should return None."""
         builder = AionRequestContextBuilder(task_store=None)

--- a/libs/aion-server/tests/unit/core/platform/websocket/test_ws_manager.py
+++ b/libs/aion-server/tests/unit/core/platform/websocket/test_ws_manager.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 
-import pytest
 
 from aion.server.core.platform import AionWebSocketManager
 
@@ -63,7 +62,6 @@ class TestAionWebSocketManager:
 
         assert ws_manager.is_connected
 
-    @pytest.mark.asyncio
     async def test_establish_connection_calls_factory_and_connect(self, ws_manager, mock_ws_transport_factory,
                                                                   mock_websocket_transport):
         """Test _establish_connection calls factory and transport connect."""
@@ -73,7 +71,6 @@ class TestAionWebSocketManager:
         mock_websocket_transport.connect.assert_called_once()
         assert ws_manager._transport == mock_websocket_transport
 
-    @pytest.mark.asyncio
     async def test_stop_sets_shutdown_event(self, ws_manager):
         """Test stop method sets shutdown event."""
         await ws_manager.stop()

--- a/libs/aion-server/tests/unit/db/test_manager.py
+++ b/libs/aion-server/tests/unit/db/test_manager.py
@@ -38,7 +38,6 @@ class TestDbManager:
         manager2 = DbManager()
         assert manager1 is manager2
 
-    @pytest.mark.asyncio
     @patch('aion.db.postgres.manager.AsyncConnectionPool')
     @patch('aion.db.postgres.manager.create_async_engine')
     @patch('aion.db.postgres.manager.async_sessionmaker')
@@ -95,7 +94,6 @@ class TestDbManager:
         assert db_manager._engine == mock_engine_instance
         assert db_manager._session_factory == mock_session_factory
 
-    @pytest.mark.asyncio
     @patch('aion.db.postgres.manager.AsyncConnectionPool')
     async def test_initialize_already_initialized(self, mock_pool_class, db_manager, sample_dsn):
         """Test initialization when already initialized."""
@@ -109,7 +107,6 @@ class TestDbManager:
         # Should not create new pool
         mock_pool_class.assert_not_called()
 
-    @pytest.mark.asyncio
     @patch('aion.db.postgres.manager.AsyncConnectionPool')
     async def test_initialize_pool_failure(self, mock_pool_class, db_manager, sample_dsn):
         """Test initialization failure when pool open fails."""
@@ -162,7 +159,6 @@ class TestDbManager:
         with pytest.raises(RuntimeError, match="Session factory not initialized"):
             db_manager.get_session()
 
-    @pytest.mark.asyncio
     async def test_close_full_cleanup(self, db_manager):
         """Test closing with all components initialized."""
         # Setup mocks for all components
@@ -185,7 +181,6 @@ class TestDbManager:
         assert db_manager._pool is None
         assert db_manager._session_factory is None
 
-    @pytest.mark.asyncio
     async def test_close_partial_cleanup(self, db_manager):
         """Test closing with only some components initialized."""
         mock_pool = AsyncMock()
@@ -197,7 +192,6 @@ class TestDbManager:
         mock_pool.close.assert_called_once()
         assert db_manager._pool is None
 
-    @pytest.mark.asyncio
     async def test_close_nothing_to_cleanup(self, db_manager):
         """Test closing when nothing is initialized."""
         # Should not raise any exceptions

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Run pytest for all libs in the monorepo.
+
+Discovers libs automatically from the libs/ directory: any subdirectory
+matching aion-* that contains a pyproject.toml is included. Libs without
+a tests/ directory are silently skipped.
+
+Usage:
+    python scripts/tests.py                        # run all libs
+    python scripts/tests.py aion-core aion-db      # run specific libs
+    python scripts/tests.py --fail-fast            # stop on first failure
+
+Examples:
+    $ make tests
+    $ python scripts/tests.py aion-core
+    $ python scripts/tests.py aion-server --fail-fast
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).parent.parent
+LIBS_DIR = ROOT_DIR / "libs"
+
+def discover_libs() -> list[str]:
+    return sorted(
+        d.name for d in LIBS_DIR.iterdir()
+        if d.is_dir() and d.name.startswith("aion-") and (d / "pyproject.toml").exists()
+    )
+
+
+def run_tests(lib_name: str) -> bool:
+    lib_dir = LIBS_DIR / lib_name
+
+    if not (lib_dir / "pyproject.toml").exists():
+        print(f"\n[SKIP] {lib_name}: no pyproject.toml")
+        return True
+
+    if not (lib_dir / "tests").exists():
+        print(f"\n[SKIP] {lib_name}: no tests directory")
+        return True
+
+    print(f"\n{'='*60}")
+    print(f"[TEST] {lib_name}")
+    print(f"{'='*60}")
+
+    result = subprocess.run(
+        ["poetry", "run", "pytest"],
+        cwd=lib_dir,
+    )
+    return result.returncode == 0
+
+
+def main():
+    args = sys.argv[1:]
+    fail_fast = "--fail-fast" in args
+    libs = [a for a in args if not a.startswith("--")]
+
+    if not LIBS_DIR.exists():
+        print("[ERROR] libs/ directory not found")
+        return 1
+
+    all_libs = discover_libs()
+
+    if not libs:
+        libs = all_libs
+    else:
+        unknown = [l for l in libs if l not in all_libs]
+        if unknown:
+            print(f"[ERROR] Unknown libs: {', '.join(unknown)}")
+            print(f"Available: {', '.join(all_libs)}")
+            return 1
+
+    passed, failed = [], []
+
+    for lib in libs:
+        ok = run_tests(lib)
+        (passed if ok else failed).append(lib)
+        if not ok and fail_fast:
+            print(f"\n[FAIL-FAST] Stopping after {lib}")
+            break
+
+    print(f"\n{'='*60}")
+    print(f"[SUMMARY] {len(passed)} passed, {len(failed)} failed")
+    if passed:
+        print(f"  passed: {', '.join(passed)}")
+    if failed:
+        print(f"  failed: {', '.join(failed)}")
+    print(f"{'='*60}")
+
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("\n[WARNING] Interrupted by user")
+        sys.exit(1)


### PR DESCRIPTION
- Add pytest-asyncio + asyncio_mode=auto to aion-api-client, aion-authoring-adk, aion-db, aion-mcp, aion-sdk
- Remove redundant @pytest.mark.asyncio decorators across all libs
- Fix aion-sdk tests: replace click with asyncclick, make CliRunner.invoke calls async
- Fix aion-authoring-adk: rename Thread constructor args id→context_id, parent_id>parent_context_id
- Add scripts/tests.py for running pytest across all libs with auto-discovery
- Add make tests target