### PR TITLE
Add A2A metadata regression coverage

### DIFF
--- a/libs/aion-core/src/aion/core/runtime/context/builder.py
+++ b/libs/aion-core/src/aion/core/runtime/context/builder.py
@@ -7,7 +7,7 @@ message metadata into a typed AionRuntimeContext object.
 from __future__ import annotations
 import logging
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from aion.core.constants import (
     DISTRIBUTION_EXTENSION_URI_V1,

--- a/libs/aion-core/tests/runtime/test_runtime_context.py
+++ b/libs/aion-core/tests/runtime/test_runtime_context.py
@@ -437,6 +437,25 @@ class TestAionRuntimeContextBuilder:
         assert result.get_principal_identity().id == "agent-1"
         assert result.get_behavior().behavior_key == "main"
 
+    def test_with_distribution_dict_metadata_returns_context_with_distribution_payload(self):
+        """Verify that decoded dict distribution metadata builds runtime context."""
+        inbox = A2AInbox(
+            message=None,
+            metadata={DISTRIBUTION_EXTENSION_URI_V1: deepcopy(_DIST_STRUCT_DATA)},
+        )
+        rc = _make_mock_rc(
+            metadata={DISTRIBUTION_EXTENSION_URI_V1: deepcopy(_DIST_STRUCT_DATA)}
+        )
+
+        with patch("aion.core.runtime.context.builder.A2AInbox.from_request_context", return_value=inbox):
+            result = AionRuntimeContextBuilder.from_request_context(rc)
+
+        assert isinstance(result, AionRuntimeContext)
+        assert result.event is None
+        assert result.distribution_extension_payload is not None
+        assert result.get_principal_identity().id == "agent-1"
+        assert result.get_behavior().behavior_key == "main"
+
     def test_with_distribution_and_event_returns_full_context(self):
         """Verify that with distribution and event returns full context."""
         inbox = _make_inbox_with_dist(include_event=True)

--- a/libs/aion-server/tests/unit/agent/test_request_executor.py
+++ b/libs/aion-server/tests/unit/agent/test_request_executor.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventQueue
-from a2a.types import TaskState
+from a2a.types import Message, Part, Role, TaskState
 from a2a.utils.errors import TaskNotCancelableError, TaskNotFoundError, UnsupportedOperationError
 
 from aion.server.agent.execution import AionAgentRequestExecutor
@@ -18,11 +18,17 @@ def _make_task(state: TaskState = TaskState.TASK_STATE_WORKING):
     return task
 
 
-def _make_context(task=None):
+def _make_context(task=None, message=None, metadata=None):
     ctx = MagicMock(spec=RequestContext)
     ctx.current_task = task
     ctx.task_id = task.id if task else None
     ctx.context_id = task.context_id if task else None
+    ctx.message = message or Message(
+        message_id="msg-123",
+        role=Role.ROLE_USER,
+        parts=[Part(text="hello")],
+    )
+    ctx.metadata = metadata
     return ctx
 
 
@@ -123,6 +129,20 @@ class TestExecuteRuntimeContext:
 
                         # Verify set_current_context was NOT called when context is None
                         MockRegistry.aset_current_context.assert_not_awaited()
+
+
+class TestGetTaskForExecution:
+    @pytest.mark.anyio
+    async def test_new_task_without_metadata_does_not_assign_none(self):
+        """A new task should omit metadata when the request context has none."""
+        ctx = _make_context(task=None, metadata=None)
+        init_execution_scope()
+
+        task, is_new_task = await AionAgentRequestExecutor._get_task_for_execution(ctx)
+
+        assert is_new_task is True
+        assert ctx.current_task == task
+        assert not task.HasField("metadata")
 
 
 class TestCancel:


### PR DESCRIPTION
## Summary

Adds regression coverage for the A2A metadata paths exercised during distribution probe validation:

- verifies decoded dict-shaped distribution metadata still builds an `AionRuntimeContext`
- verifies new tasks omit protobuf metadata when the request context has no metadata
- removes an unused `Any` import left in the runtime context builder after the shared metadata normalization landed upstream

## Root cause

The probe validation exposed two metadata edge cases: distribution metadata can arrive as already-decoded dictionaries, and direct A2A requests can have no request metadata. Both paths need regression coverage so future SDK changes do not reintroduce the runtime-context parsing issue or the protobuf `None` metadata assignment error.

## Validation

- `poetry run pytest tests/runtime/test_runtime_context.py -q` from `libs/aion-core` -> `36 passed`
- `PYTHONPATH="/Users/kavyalakshmiguttikonda/Desktop/aion-python-sdk/libs/aion-server/src:/Users/kavyalakshmiguttikonda/Desktop/aion-python-sdk/libs/aion-core/src:/Users/kavyalakshmiguttikonda/Desktop/aion-python-sdk/libs/aion-db/src:/Users/kavyalakshmiguttikonda/Desktop/aion-python-sdk/libs/aion-server-langgraph/src:/Users/kavyalakshmiguttikonda/Desktop/aion-python-sdk/libs/aion-api-client/src" /Users/kavyalakshmiguttikonda/Desktop/agents/packages/langgraph/probe_agent/.venv/bin/python -m pytest libs/aion-server/tests/unit/agent/test_request_executor.py -q` -> `11 passed, 3 warnings`