### PR TITLE
fix: pin a2a-sdk to exact 1.0.3 and fix CLI module entrypoint

### DIFF
--- a/libs/aion-core/pyproject.toml
+++ b/libs/aion-core/pyproject.toml
@@ -12,7 +12,7 @@ pydantic = ">=2.11.3"
 pydantic-settings = ">=2.3.4"
 python-dotenv = ">=1.0.1"
 PyYAML = "^6.0.0"
-a2a-sdk = "^1.0.3"
+a2a-sdk = "1.0.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"

--- a/libs/aion-sdk/src/aion/cli/__init__.py
+++ b/libs/aion-sdk/src/aion/cli/__init__.py
@@ -1,5 +1,1 @@
 """Aion Agent CLI package."""
-
-from aion.cli.cli import cli
-
-__all__ = ["cli"]

--- a/libs/aion-sdk/src/aion/cli/__main__.py
+++ b/libs/aion-sdk/src/aion/cli/__main__.py
@@ -1,0 +1,7 @@
+"""Allow running the CLI as ``python -m aion.cli``."""
+
+from aion.cli.cli import cli
+
+
+if __name__ == "__main__":
+    cli()

--- a/libs/aion-server/pyproject.toml
+++ b/libs/aion-server/pyproject.toml
@@ -13,7 +13,7 @@ fastapi = ">=0.115.2"
 pydantic-settings = ">=2.3.4"
 python-dotenv = ">=1.0.1"
 PyYAML = "^6.0.0"
-a2a-sdk = { extras = ["http-server", "telemetry"], version = "^1.0.3" }
+a2a-sdk = { extras = ["http-server", "telemetry"], version = "1.0.3" }
 python-logstash-async = "^4.0.1"
 
 aion-core = { git = "https://github.com/Terminal-Research/aion-python-sdk", branch = "main", subdirectory = "libs/aion-core" }


### PR DESCRIPTION
Pin a2a-sdk version to avoid picking up incompatible ^1.0.x releases, and move the cli import to __main__.py so `python -m aion.cli` works without eagerly importing cli from the package __init__.