### PR TITLE
fix: match distribution extension models to the 1.0.0 spec

### DIFF
--- a/libs/aion-authoring-langgraph/tests/helpers.py
+++ b/libs/aion-authoring-langgraph/tests/helpers.py
@@ -25,7 +25,8 @@ def make_mock_distribution_extension(endpoint_type="A2A", include_principal=True
             PrincipalIdentity(
                 kind="principal",
                 id="agent-1",
-                network_type="aion",
+                identity_network="aion",
+                identity_kind="Personal",
                 organization_id="org-1",
             )
         )
@@ -34,7 +35,8 @@ def make_mock_distribution_extension(endpoint_type="A2A", include_principal=True
             ServiceIdentity(
                 kind="service",
                 id="svc-1",
-                network_type=endpoint_type,
+                identity_network=endpoint_type,
+                identity_kind="User",
                 organization_id="org-1",
             )
         )
@@ -50,6 +52,7 @@ def make_mock_distribution_extension(endpoint_type="A2A", include_principal=True
         environment=Environment(
             id="env-1",
             name="prod",
+            project_id="proj-1",
             deployment_id="dep-1",
             configuration_variables={},
         ),

--- a/libs/aion-chat-ui/src/lib/a2aMetadata.ts
+++ b/libs/aion-chat-ui/src/lib/a2aMetadata.ts
@@ -13,7 +13,6 @@ export interface MetadataOptions {
 	agentUsername?: string;
 	behaviorKey?: string;
 	environmentName?: string;
-	systemPrompt?: string;
 	senderId?: string;
 	nodeId?: string;
 }
@@ -37,42 +36,42 @@ export function generateTaskMetadata(
 
 	return {
 		[DISTRIBUTION_EXTENSION_URI_V1]: {
-			sender_id: senderId,
+			senderId,
 			distribution: {
 				id: crypto.randomUUID(),
-				endpoint_type: "Aion",
+				endpointType: "Aion",
 				url: "https://example.com/agent-card",
 				identities: [
 					{
 						kind: "principal",
 						id: crypto.randomUUID(),
-						network_type: "Aion",
-						represented_user_id: crypto.randomUUID(),
-						organization_id: orgId,
-						display_name: agentName,
-						user_name: agentUsername,
-						avatar_image_url: "https://example.com/avatar.png",
-						agent_type: "Deployed",
+						identityNetwork: "Aion",
+						identityKind: "Personal",
+						representedUserId: crypto.randomUUID(),
+						organizationId: orgId,
+						displayName: agentName,
+						userName: agentUsername,
+						avatarImageUrl: "https://example.com/avatar.png",
+						agentType: "Personal",
 						url: "https://example.com/agent"
 					}
 				]
 			},
 			behavior: {
 				id: crypto.randomUUID(),
-				behavior_key: behaviorKey,
-				version_id: crypto.randomUUID()
+				behaviorKey: behaviorKey,
+				versionId: crypto.randomUUID()
 			},
 			environment: {
 				id: crypto.randomUUID(),
 				name: environmentName,
-				deployment_id: crypto.randomUUID(),
-				configuration_variables: {
+				projectId: crypto.randomUUID(),
+				deploymentId: crypto.randomUUID(),
+				configurationVariables: {
 					API_TIMEOUT: "30",
 					MAX_RETRIES: "3",
 					LOG_LEVEL: "INFO"
-				},
-				system_prompt:
-					options.systemPrompt ?? `You are ${agentName}, a helpful assistant.`
+				}
 			}
 		},
 		[TRACEABILITY_EXTENSION_URI_V1]: {

--- a/libs/aion-chat-ui/test/a2aMetadata.test.ts
+++ b/libs/aion-chat-ui/test/a2aMetadata.test.ts
@@ -15,12 +15,49 @@ describe("generateTaskMetadata", () => {
 		});
 
 		expect(metadata[DISTRIBUTION_EXTENSION_URI_V1]).toMatchObject({
-			sender_id: "sender-1"
+			senderId: "sender-1"
 		});
 		expect(metadata[TRACEABILITY_EXTENSION_URI_V1]).toMatchObject({
 			baggage: expect.objectContaining({
 				channel: "cli"
 			})
 		});
+	});
+
+	it("emits the distribution payload in the camelCase shape the spec defines", () => {
+		// The agent-side model accepts snake_case field names too, so a drifted
+		// fixture parses anyway; assert the wire names the spec actually mandates.
+		// https://docs.aion.to/a2a/extensions/aion/distribution/1.0.0
+		const payload = generateTaskMetadata() as Record<string, any>;
+		const distribution = payload[DISTRIBUTION_EXTENSION_URI_V1];
+
+		expect(Object.keys(distribution.distribution)).toEqual(
+			expect.arrayContaining(["id", "endpointType", "url", "identities"])
+		);
+		expect(Object.keys(distribution.distribution.identities[0])).toEqual(
+			expect.arrayContaining([
+				"kind",
+				"id",
+				"identityNetwork",
+				"identityKind",
+				"organizationId"
+			])
+		);
+		expect(Object.keys(distribution.behavior)).toEqual(
+			expect.arrayContaining(["id", "behaviorKey", "versionId"])
+		);
+		expect(Object.keys(distribution.environment)).toEqual(
+			expect.arrayContaining([
+				"id",
+				"name",
+				"projectId",
+				"deploymentId",
+				"configurationVariables"
+			])
+		);
+		// agentType is constrained by the spec; "Deployed" is not a member.
+		expect(["Personal", "Principal", "Daemon", "System"]).toContain(
+			distribution.distribution.identities[0].agentType
+		);
 	});
 });

--- a/libs/aion-core/src/aion/core/a2a/extensions/distribution.py
+++ b/libs/aion-core/src/aion/core/a2a/extensions/distribution.py
@@ -39,15 +39,19 @@ class PrincipalIdentity(A2ABaseModel):
     id: str = Field(
         description="Identity id for the principal associated with this distribution."
     )
-    network_type: Optional[str] = Field(
-        default=None,
+    identity_network: str = Field(
         description=(
             "Communication-network namespace for the identity, matching the "
-            "control-plane network type values such as Aion, A2A, Telegram, or "
-            "Twitter. None when the distribution projection did not supply one; "
-            "treat it as unknown rather than assuming a network, and compare "
-            "case-insensitively."
-        ),
+            "control-plane identity network values such as Aion, A2A, Telegram, or "
+            "Twitter. Compare case-insensitively."
+        )
+    )
+    identity_kind: str = Field(
+        description=(
+            "Agent type category for this principal identity, such as Personal, "
+            "Principal, Daemon, or System. Mirrors agent_type for principal "
+            "identities."
+        )
     )
     organization_id: str = Field(description="Owning organization id.")
     represented_user_id: Optional[str] = Field(
@@ -105,14 +109,17 @@ class ServiceIdentity(A2ABaseModel):
     id: str = Field(
         description="Identity id for the service identity associated with this distribution."
     )
-    network_type: Optional[str] = Field(
-        default=None,
+    identity_network: str = Field(
         description=(
             "External communication-network namespace for the identity, such as "
-            "Telegram, Twitter, or GitHub. None when the distribution projection "
-            "did not supply one; treat it as unknown rather than assuming a "
-            "network, and compare case-insensitively."
-        ),
+            "Telegram, Twitter, or GitHub. Compare case-insensitively."
+        )
+    )
+    identity_kind: str = Field(
+        description=(
+            "External principal category for this service identity, such as Bot, "
+            "PhoneNumber, or User."
+        )
     )
     organization_id: str = Field(description="Owning organization id.")
     represented_user_id: Optional[str] = Field(
@@ -158,6 +165,14 @@ class Distribution(A2ABaseModel):
     url: str = Field(
         description="Distribution-facing A2A URL; currently sourced from the principal identity A2A URL."
     )
+    component_agent_card_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "Agent-card discovery URL for the environment backing this distribution, "
+            "addressing the node as a singular agent rather than as the distribution "
+            "sequence entrypoint. None when the projection did not supply one."
+        ),
+    )
     identities: List[Identity] = Field(
         description=(
             "Identities associated directly with this distribution. A distribution "
@@ -196,6 +211,7 @@ class Environment(A2ABaseModel):
 
     id: str = Field(description="Environment id in the Aion control plane.")
     name: str = Field(description="Human-readable environment name.")
+    project_id: str = Field(description="Project that owns this environment.")
     deployment_id: str = Field(
         description="Deployment id associated with this environment."
     )
@@ -209,10 +225,6 @@ class Environment(A2ABaseModel):
     daemon_agent_identity_id: Optional[str] = Field(
         default=None,
         description="Daemon agent identity id assigned for internal addressing.",
-    )
-    system_prompt: Optional[str] = Field(
-        default=None,
-        description="System prompt associated with this environment, when provided.",
     )
 
     def get_configuration_variable(self, key: str) -> Optional[str]:
@@ -234,10 +246,6 @@ class DistributionExtensionV1(A2ABaseModel):
     Spec: https://docs.aion.to/a2a/extensions/aion/distribution/1.0.0
     """
 
-    version: Literal["1.0.0"] = Field(
-        default="1.0.0",
-        description="Distribution extension schema version used to parse this payload.",
-    )
     sender_id: Optional[str] = Field(
         default=None,
         description="Source-network sender identifier for this request.",

--- a/libs/aion-core/tests/a2a/test_a2a_types.py
+++ b/libs/aion-core/tests/a2a/test_a2a_types.py
@@ -37,6 +37,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from a2a.types import Artifact, Message, Role, Task, TaskState, TaskStatus
+from pydantic import ValidationError
 
 from aion.core.a2a.enums import (
     A2AEventType,
@@ -580,7 +581,8 @@ def _make_distribution() -> Distribution:
     identity = PrincipalIdentity(
         kind="principal",
         id="agent-1",
-        network_type="slack",
+        identity_network="slack",
+        identity_kind="Personal",
         organization_id="org-1",
     )
     return Distribution(
@@ -603,6 +605,7 @@ def _make_environment() -> Environment:
     return Environment(
         id="env-1",
         name="production",
+        project_id="proj-1",
         deployment_id="dep-1",
         configuration_variables={"KEY": "VALUE"},
     )
@@ -610,11 +613,12 @@ def _make_environment() -> Environment:
 
 class TestDistributionExtension:
     def test_principal_identity(self):
-        """PrincipalIdentity stores kind, id, network_type and defaults optional fields to None."""
+        """PrincipalIdentity stores kind, id, identity_network and defaults optional fields to None."""
         r = PrincipalIdentity(
             kind="principal",
             id="a1",
-            network_type="slack",
+            identity_network="slack",
+            identity_kind="Personal",
             organization_id="org-1",
         )
         assert r.kind == "principal"
@@ -626,17 +630,18 @@ class TestDistributionExtension:
         r = ServiceIdentity(
             kind="service",
             id="s1",
-            network_type="webhook",
+            identity_network="webhook",
+            identity_kind="User",
             organization_id="org-2",
         )
         assert r.kind == "service"
 
-    def test_identity_network_type_is_optional(self):
-        """Identities omit network_type when the distribution projection has none."""
-        principal = PrincipalIdentity(kind="principal", id="a1", organization_id="org-1")
-        service = ServiceIdentity(kind="service", id="s1", organization_id="org-1")
-        assert principal.network_type is None
-        assert service.network_type is None
+    def test_identity_requires_identity_network_and_kind(self):
+        """The spec marks identityNetwork and identityKind required on both identity kinds."""
+        with pytest.raises(ValidationError):
+            PrincipalIdentity(kind="principal", id="a1", organization_id="org-1")
+        with pytest.raises(ValidationError):
+            ServiceIdentity(kind="service", id="s1", organization_id="org-1")
 
     def test_distribution_with_identities(self):
         """Distribution stores identities list and id correctly."""
@@ -659,29 +664,36 @@ class TestDistributionExtension:
         assert env.get_configuration_variable("KEY") == "VALUE"
         assert env.get_configuration_variable("MISSING") is None
         assert env.daemon_agent_identity_id is None
-        assert env.system_prompt is None
 
     def test_environment_with_optional_fields(self):
-        """Environment stores daemon_agent_identity_id and system_prompt when provided."""
+        """Environment stores daemon_agent_identity_id when provided."""
         env = Environment(
             id="env-2",
             name="staging",
+            project_id="proj-2",
             deployment_id="dep-2",
             configuration_variables={},
             daemon_agent_identity_id="daemon-1",
-            system_prompt="You are helpful.",
         )
         assert env.daemon_agent_identity_id == "daemon-1"
-        assert env.system_prompt == "You are helpful."
+
+    def test_environment_requires_project_id(self):
+        """The spec marks projectId required on the environment record."""
+        with pytest.raises(ValidationError):
+            Environment(
+                id="env-3",
+                name="staging",
+                deployment_id="dep-3",
+                configuration_variables={},
+            )
 
     def test_distribution_extension_v1(self):
-        """DistributionExtensionV1 defaults version to '1.0.0' and sender_id to None."""
+        """DistributionExtensionV1 defaults sender_id to None."""
         ext = DistributionExtensionV1(
             distribution=_make_distribution(),
             behavior=_make_behavior(),
             environment=_make_environment(),
         )
-        assert ext.version == "1.0.0"
         assert ext.sender_id is None
 
     def test_distribution_extension_with_sender_id(self):
@@ -705,7 +717,8 @@ class TestDistributionExtension:
         svc_identity = ServiceIdentity(
             kind="service",
             id="s1",
-            network_type="webhook",
+            identity_network="webhook",
+            identity_kind="User",
             organization_id="org-1",
         )
         rec = Distribution(

--- a/libs/aion-core/tests/runtime/test_runtime_context.py
+++ b/libs/aion-core/tests/runtime/test_runtime_context.py
@@ -77,7 +77,8 @@ def _make_distribution_ext(
             PrincipalIdentity(
                 kind="principal",
                 id=agent_id,
-                network_type="aion",
+                identity_network="aion",
+                identity_kind="Personal",
                 organization_id="org-1",
                 display_name="Bot",
                 user_name="bot",
@@ -88,7 +89,8 @@ def _make_distribution_ext(
             ServiceIdentity(
                 kind="service",
                 id="svc-1",
-                network_type="slack",
+                identity_network="slack",
+                identity_kind="User",
                 organization_id="org-1",
                 display_name="Slack App",
             )
@@ -105,6 +107,7 @@ def _make_distribution_ext(
         environment=Environment(
             id=env_id,
             name=env_name,
+            project_id="proj-1",
             deployment_id="dep-1",
             configuration_variables=config_vars or {},
             daemon_agent_identity_id=daemon_agent_identity_id,
@@ -220,7 +223,7 @@ class TestAionRuntimeContextDistributionPayload:
         assert identity.id == "agent-abc"
         assert identity.display_name == "Bot"
         assert identity.user_name == "bot"
-        assert identity.network_type == "aion"
+        assert identity.identity_network == "aion"
 
     def test_service_identity_extracted(self):
         """Verify that service identity is read from the distribution payload."""
@@ -230,7 +233,7 @@ class TestAionRuntimeContextDistributionPayload:
         service_identity = ctx.get_service_identity()
 
         assert service_identity.id == "svc-1"
-        assert service_identity.network_type == "slack"
+        assert service_identity.identity_network == "slack"
 
     def test_behavior_returned(self):
         """Verify that behavior is returned from the distribution payload."""
@@ -335,7 +338,8 @@ _DIST_STRUCT_DATA = {
             {
                 "kind": "principal",
                 "id": "agent-1",
-                "networkType": "aion",
+                "identityNetwork": "aion",
+                "identityKind": "Personal",
                 "organizationId": "org-1",
                 "displayName": "Bot",
                 "userName": "bot",
@@ -350,6 +354,7 @@ _DIST_STRUCT_DATA = {
     "environment": {
         "id": "env-1",
         "name": "prod",
+        "projectId": "proj-1",
         "deploymentId": "dep-1",
         "configurationVariables": {},
     },
@@ -363,7 +368,8 @@ def _make_dist_struct(include_principal: bool = True) -> Struct:
             {
                 "kind": "service",
                 "id": "svc-1",
-                "networkType": "slack",
+                "identityNetwork": "slack",
+                "identityKind": "User",
                 "organizationId": "org-1",
             }
         ]

--- a/libs/aion-sdk/src/aion/cli/bin/cli.mjs
+++ b/libs/aion-sdk/src/aion/cli/bin/cli.mjs
@@ -54088,41 +54088,42 @@ function generateTaskMetadata(options = {}) {
   const orgId = crypto.randomUUID();
   return {
     [DISTRIBUTION_EXTENSION_URI_V1]: {
-      sender_id: senderId,
+      senderId,
       distribution: {
         id: crypto.randomUUID(),
-        endpoint_type: "Aion",
+        endpointType: "Aion",
         url: "https://example.com/agent-card",
         identities: [
           {
             kind: "principal",
             id: crypto.randomUUID(),
-            network_type: "Aion",
-            represented_user_id: crypto.randomUUID(),
-            organization_id: orgId,
-            display_name: agentName,
-            user_name: agentUsername,
-            avatar_image_url: "https://example.com/avatar.png",
-            agent_type: "Deployed",
+            identityNetwork: "Aion",
+            identityKind: "Personal",
+            representedUserId: crypto.randomUUID(),
+            organizationId: orgId,
+            displayName: agentName,
+            userName: agentUsername,
+            avatarImageUrl: "https://example.com/avatar.png",
+            agentType: "Personal",
             url: "https://example.com/agent"
           }
         ]
       },
       behavior: {
         id: crypto.randomUUID(),
-        behavior_key: behaviorKey,
-        version_id: crypto.randomUUID()
+        behaviorKey,
+        versionId: crypto.randomUUID()
       },
       environment: {
         id: crypto.randomUUID(),
         name: environmentName,
-        deployment_id: crypto.randomUUID(),
-        configuration_variables: {
+        projectId: crypto.randomUUID(),
+        deploymentId: crypto.randomUUID(),
+        configurationVariables: {
           API_TIMEOUT: "30",
           MAX_RETRIES: "3",
           LOG_LEVEL: "INFO"
-        },
-        system_prompt: options.systemPrompt ?? `You are ${agentName}, a helpful assistant.`
+        }
       }
     },
     [TRACEABILITY_EXTENSION_URI_V1]: {

--- a/libs/aion-server/src/aion/server/core/middlewares/aion_context.py
+++ b/libs/aion-server/src/aion/server/core/middlewares/aion_context.py
@@ -118,21 +118,9 @@ class AionContextMiddleware(BaseHTTPMiddleware):
         raw = metadata.get(DISTRIBUTION_EXTENSION_URI_V1)
         if raw is None:
             return None
-        extension = DistributionExtensionV1.model_validate(raw)
-
-        # networkType is optional on the wire but every identity is expected to
-        # carry one; a missing value points at the distribution projection
-        # upstream, so surface it instead of silently defaulting a network.
-        for identity in extension.distribution.identities:
-            if identity.network_type is None:
-                logger.warning(
-                    "Distribution %s sent %s identity %s without networkType",
-                    extension.distribution.id,
-                    identity.kind,
-                    identity.id,
-                )
-
-        return extension
+        # Required spec fields are enforced by the model, so a projection that
+        # omits one raises here rather than reaching the agent with silent gaps.
+        return DistributionExtensionV1.model_validate(raw)
 
     @staticmethod
     def _get_traceability_extension(metadata: dict[str, Any]) -> TraceabilityExtensionV1 | None:

--- a/libs/aion-server/tests/unit/core/test_aion_context_middleware.py
+++ b/libs/aion-server/tests/unit/core/test_aion_context_middleware.py
@@ -1,27 +1,39 @@
 import logging
 
+import pytest
+from pydantic import ValidationError
+
 from aion.core.constants import DISTRIBUTION_EXTENSION_URI_V1
 from aion.server.core.middlewares.aion_context import AionContextMiddleware
 
 
 # !! Test Data Factories !!
 def create_distribution_payload(identity_overrides=None):
-    """Factory function to build a distribution extension payload as sent by the control plane."""
+    """Factory function to build a distribution extension payload as sent by the control plane.
+
+    Field names and shape mirror a payload captured from staging, so this factory
+    doubles as the contract check against the published extension spec at
+    https://docs.aion.to/a2a/extensions/aion/distribution/1.0.0.
+    """
     identity = {
         "kind": "principal",
         "id": "identity-1",
-        "networkType": "Aion",
+        "identityNetwork": "Aion",
+        "identityKind": "Personal",
+        "representedUserId": "user-1",
         "organizationId": "org-1",
+        "displayName": "Artem Sosnytskyi",
+        "userName": "sosnytskyi_artem_dev",
         "agentType": "Personal",
     }
     identity.update(identity_overrides or {})
 
     return {
-        "version": "1.0.0",
         "distribution": {
             "id": "dist-1",
-            "endpointType": "Aion",
-            "url": "https://example.com/agent",
+            "endpointType": "A2A",
+            "url": "https://example.com/distributions/dist-1/a2a/.well-known/agent-card.json",
+            "componentAgentCardUrl": "https://example.com/environments/env-1/a2a/.well-known/agent-card.json",
             "identities": [identity],
         },
         "behavior": {
@@ -32,6 +44,7 @@ def create_distribution_payload(identity_overrides=None):
         "environment": {
             "id": "env-1",
             "name": "Development",
+            "projectId": "proj-1",
             "deploymentId": "dep-1",
             "configurationVariables": {},
         },
@@ -40,40 +53,62 @@ def create_distribution_payload(identity_overrides=None):
 
 # !! Tests !!
 class TestGetDistributionExtension:
-    def test_parses_payload_with_network_type(self, caplog):
+    def test_parses_payload_with_identity_network(self, caplog):
         """A fully populated identity parses and logs no warning."""
         metadata = {DISTRIBUTION_EXTENSION_URI_V1: create_distribution_payload()}
 
         with caplog.at_level(logging.WARNING):
             extension = AionContextMiddleware._get_distribution_extension(metadata)
 
-        assert extension.distribution.identities[0].network_type == "Aion"
+        assert extension.distribution.identities[0].identity_network == "Aion"
         assert caplog.records == []
 
-    def test_parses_payload_without_network_type(self, caplog):
-        """A missing networkType leaves the field unset instead of rejecting the request."""
+    @pytest.mark.parametrize(
+        "field",
+        ["identityNetwork", "identityKind", "organizationId"],
+    )
+    def test_rejects_identity_missing_required_field(self, field):
+        """The spec marks these identity fields required, so omitting one is an error."""
         payload = create_distribution_payload()
-        del payload["distribution"]["identities"][0]["networkType"]
+        del payload["distribution"]["identities"][0][field]
         metadata = {DISTRIBUTION_EXTENSION_URI_V1: payload}
 
-        with caplog.at_level(logging.WARNING):
-            extension = AionContextMiddleware._get_distribution_extension(metadata)
-
-        assert extension.distribution.identities[0].network_type is None
-
-    def test_warns_when_network_type_missing(self, caplog):
-        """A missing networkType is surfaced as a warning naming the distribution and identity."""
-        payload = create_distribution_payload()
-        del payload["distribution"]["identities"][0]["networkType"]
-        metadata = {DISTRIBUTION_EXTENSION_URI_V1: payload}
-
-        with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValidationError):
             AionContextMiddleware._get_distribution_extension(metadata)
 
-        assert len(caplog.records) == 1
-        message = caplog.records[0].getMessage()
-        assert "dist-1" in message
-        assert "identity-1" in message
+    @pytest.mark.parametrize(
+        "field",
+        ["projectId", "deploymentId", "configurationVariables"],
+    )
+    def test_rejects_environment_missing_required_field(self, field):
+        """The spec marks these environment fields required, so omitting one is an error."""
+        payload = create_distribution_payload()
+        del payload["environment"][field]
+        metadata = {DISTRIBUTION_EXTENSION_URI_V1: payload}
+
+        with pytest.raises(ValidationError):
+            AionContextMiddleware._get_distribution_extension(metadata)
+
+    def test_binds_every_field_the_control_plane_sends(self):
+        """Every field in a real control-plane payload lands on the model.
+
+        Guards against the failure mode where a renamed wire field is silently
+        dropped by extra="ignore" and the attribute just reads as None.
+        """
+        payload = create_distribution_payload()
+        metadata = {DISTRIBUTION_EXTENSION_URI_V1: payload}
+
+        extension = AionContextMiddleware._get_distribution_extension(metadata)
+
+        identity = extension.distribution.identities[0]
+        assert identity.identity_network == "Aion"
+        assert identity.identity_kind == "Personal"
+        assert identity.agent_type == "Personal"
+        assert identity.represented_user_id == "user-1"
+        assert extension.distribution.component_agent_card_url.endswith(
+            "/environments/env-1/a2a/.well-known/agent-card.json"
+        )
+        assert extension.environment.project_id == "proj-1"
 
     def test_returns_none_without_extension(self):
         """Metadata without the distribution extension yields no payload."""


### PR DESCRIPTION
Identities and environments arrive as identityNetwork, identityKind and projectId. The models looked for networkType and had no field for the other two, so extra="ignore" discarded them without a trace.