### PR TITLE
Derive the Logstash endpoint from LOGSTASH_HOST and authenticate to t…

### DIFF
--- a/libs/aion-server/src/aion/server/logging/handlers/logstash/__init__.py
+++ b/libs/aion-server/src/aion/server/logging/handlers/logstash/__init__.py
@@ -1,0 +1,23 @@
+"""Logstash integration: endpoint resolution, formatting, transport and handler.
+
+The pieces are split by responsibility: :mod:`endpoint` resolves *where* to
+send, :mod:`filter` and :mod:`formatter` decide *what* is sent, :mod:`transport`
+performs the delivery (including Aion platform authentication), and
+:mod:`handler` wires them together.
+"""
+
+from .endpoint import LogstashEndpoint, is_platform_host, resolve_logstash_endpoint
+from .filter import AionLogstashFilter
+from .formatter import AionLogstashFormatter
+from .handler import AionLogstashHandler
+from .transport import AionLogstashTransport
+
+__all__ = [
+    "AionLogstashFilter",
+    "AionLogstashFormatter",
+    "AionLogstashHandler",
+    "AionLogstashTransport",
+    "LogstashEndpoint",
+    "is_platform_host",
+    "resolve_logstash_endpoint",
+]

--- a/libs/aion-server/src/aion/server/logging/handlers/logstash/endpoint.py
+++ b/libs/aion-server/src/aion/server/logging/handlers/logstash/endpoint.py
@@ -1,0 +1,153 @@
+"""Resolution of the Logstash endpoint from environment configuration.
+
+``LOGSTASH_HOST`` accepts either a full URL or a bare host, and everything
+else -- scheme, port, path and whether to authenticate with an Aion platform
+token -- is derived from it. This module holds that derivation so the parsing
+rules live in one place instead of being spread across settings and setup,
+and sits next to the handler and transport that consume the result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlsplit
+
+__all__ = ["LogstashEndpoint", "resolve_logstash_endpoint"]
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+@dataclass(frozen=True)
+class LogstashEndpoint:
+    """A fully resolved Logstash destination.
+
+    Attributes:
+        scheme: Either ``http`` or ``https``.
+        host: Hostname of the Logstash endpoint.
+        port: Resolved port, defaulting to the default port of the scheme.
+        path: Path without the leading slash ('' for the root path).
+        use_platform_auth: Whether to send an Aion platform Bearer token.
+    """
+
+    scheme: str
+    host: str
+    port: int
+    path: str
+    use_platform_auth: bool
+
+    @property
+    def url(self) -> str:
+        """Return the endpoint URL as sent to."""
+        return f"{self.scheme}://{self.host}:{self.port}/{self.path}"
+
+    def describe(self) -> str:
+        """Return a human readable summary for startup diagnostics."""
+        auth = "enabled" if self.use_platform_auth else "disabled"
+        return f"{self.url} (platform auth: {auth})"
+
+
+def is_platform_host(host: str, platform_host: Optional[str]) -> bool:
+    """Return True when ``host`` belongs to the Aion platform domain.
+
+    The comparison is made against the registrable domain of the configured
+    Aion API host, so that every environment (production, staging, ...) is
+    recognised without hardcoding a domain.
+
+    Matching is exact-or-subdomain on the parsed hostname. A substring check
+    would be unsafe here: the platform token is a full client credential, and
+    ``"aion.to" in host`` also matches unrelated domains such as
+    ``aion.tools`` or ``aion.torture.com``.
+
+    Args:
+        host: Hostname of the Logstash endpoint.
+        platform_host: Hostname of the Aion API (e.g. ``api.aion.to``).
+    """
+    if not host or not platform_host:
+        return False
+
+    domain = _registrable_domain(platform_host)
+    if not domain:
+        return False
+
+    host = host.lower().rstrip(".")
+    return host == domain or host.endswith(f".{domain}")
+
+
+def _registrable_domain(host: str) -> str:
+    """Return the last two labels of a hostname ('api.aion.to' -> 'aion.to')."""
+    labels = host.lower().rstrip(".").split(".")
+    if len(labels) < 2:
+        return ""
+    return ".".join(labels[-2:])
+
+
+def resolve_logstash_endpoint(
+        raw_host: Optional[str],
+        raw_port: Optional[int],
+        platform_host: Optional[str],
+) -> Optional[LogstashEndpoint]:
+    """Resolve the Logstash endpoint, or None when logging is not configured.
+
+    ``raw_host`` may be a full URL (``https://logs.aion.to/ingest``) or a bare
+    host (``localhost``, ``logs.aion.to:5000``). The scheme defaults to HTTPS
+    for Aion platform hosts and to HTTP otherwise; the port falls back to
+    ``raw_port`` and then to the default port of the scheme.
+
+    Args:
+        raw_host: Value of LOGSTASH_HOST.
+        raw_port: Value of LOGSTASH_PORT, used only when the host carries no port.
+        platform_host: Hostname of the Aion API, used to detect platform endpoints.
+
+    Raises:
+        ValueError: If the host is malformed or uses an unsupported scheme.
+    """
+    if not raw_host:
+        return None
+
+    raw_host = raw_host.strip()
+    if not raw_host:
+        return None
+
+    scheme, host, port, path = _split(raw_host)
+
+    if not host:
+        raise ValueError(f"LOGSTASH_HOST does not contain a hostname: {raw_host!r}")
+
+    on_platform = is_platform_host(host, platform_host)
+    if scheme is None:
+        scheme = "https" if on_platform else "http"
+
+    return LogstashEndpoint(
+        scheme=scheme,
+        host=host,
+        port=port or raw_port or _DEFAULT_PORTS[scheme],
+        path=path,
+        # A bearer credential is never put on the wire in the clear, so a
+        # platform host reached over plain HTTP gets no token.
+        use_platform_auth=on_platform and scheme == "https",
+    )
+
+
+def _split(raw_host: str) -> tuple[Optional[str], Optional[str], Optional[int], str]:
+    """Split LOGSTASH_HOST into (scheme, host, port, path).
+
+    The scheme is None when the value is a bare host. Note that a bare host
+    cannot be handed to urlsplit directly: it parses ``localhost:5000`` as
+    scheme ``localhost`` with path ``5000``.
+    """
+    has_scheme = "://" in raw_host
+    parsed = urlsplit(raw_host if has_scheme else f"//{raw_host}")
+
+    scheme = parsed.scheme.lower() if has_scheme else None
+    if scheme is not None and scheme not in _DEFAULT_PORTS:
+        raise ValueError(
+            f"LOGSTASH_HOST has an unsupported scheme {scheme!r}; "
+            f"expected one of {sorted(_DEFAULT_PORTS)}")
+
+    try:
+        port = parsed.port
+    except ValueError as ex:
+        raise ValueError(f"LOGSTASH_HOST has an invalid port: {raw_host!r}") from ex
+
+    return scheme, parsed.hostname, port, parsed.path.strip("/")

--- a/libs/aion-server/src/aion/server/logging/handlers/logstash/filter.py
+++ b/libs/aion-server/src/aion/server/logging/handlers/logstash/filter.py
@@ -1,0 +1,42 @@
+"""Record filter deciding which log records are worth shipping to Logstash."""
+
+import logging
+
+from aion.core.logging.base import AionLogRecord
+
+__all__ = ["AionLogstashFilter"]
+
+
+class AionLogstashFilter(logging.Filter):
+    """Filter log records for Logstash processing.
+
+    Only allows records with INFO level or higher that contain
+    valid request context information.
+    """
+
+    def filter(self, record: AionLogRecord) -> bool:
+        if not self._validate_log_level(record):
+            return False
+
+        if not any((
+                self._validate_deployment(record),
+                self._validate_tracing(record))
+        ):
+            return False
+
+        return True
+
+    @staticmethod
+    def _validate_log_level(record: AionLogRecord):
+        return record.levelno > logging.DEBUG
+
+    @staticmethod
+    def _validate_deployment(record: AionLogRecord):
+        return bool(
+            getattr(record, 'aion_distribution_id', None) or
+            getattr(record, 'aion_version_id', None)
+        )
+
+    @staticmethod
+    def _validate_tracing(record: AionLogRecord):
+        return bool(getattr(record, 'trace_id', None))

--- a/libs/aion-server/src/aion/server/logging/handlers/logstash/formatter.py
+++ b/libs/aion-server/src/aion/server/logging/handlers/logstash/formatter.py
@@ -1,0 +1,112 @@
+"""Formatting of log records into the JSON structure Logstash ingests."""
+
+import datetime
+import json
+import os
+import traceback
+
+from a2a.types import TaskState
+from aion.core.logging.base import AionLogRecord
+from logstash_async.formatter import LogstashFormatter
+
+from aion.server.utils.deployment import get_service_name
+
+__all__ = ["AionLogstashFormatter"]
+
+
+_LOG_LEVEL_MAP = {
+    "WARNING": "WARN",
+    "CRITICAL": "FATAL",
+}
+
+
+class AionLogstashFormatter(LogstashFormatter):
+    """Format log records into Logstash-compatible JSON format.
+
+    Args:
+        client_id: Unique identifier for the client.
+        node_name: Name of the node generating the logs.
+        **kwargs: Additional arguments passed to LogstashFormatter.
+    """
+
+    def __init__(self, client_id: str, node_name: str, **kwargs):
+        super().__init__(**kwargs)
+        self._client_id = client_id
+        self._node_name = node_name
+
+    def format(self, record: AionLogRecord) -> str:
+        """Create a structured log entry formatted for Logstash ingestion.
+
+        Generates a dictionary containing all required and optional fields
+        according to Logstash specification, including timestamp, log level,
+        message, host information, service metadata, tracing context, and exception details.
+
+        Returns:
+            Dict[str, Any]: Structured log entry with the following keys:
+                - @timestamp: ISO 8601 formatted UTC timestamp
+                - clientId: Client identifier
+                - logLevel: Log level name (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+                - message: Formatted log message
+                - host.name: Node/host name
+                - process.pid: Process ID
+                - service.name: Service identifier (defaults to "aion-langgraph-server")
+                - logger: Logger name (optional, only if present in record)
+                - trace.id: Trace ID in hex format (from SpanInfo if available)
+                - span.id: Span ID in hex format (from SpanInfo if available)
+                - span.name: Span name (from SpanInfo if available)
+                - parent.span.id: Parent span ID in hex format (from SpanInfo if available)
+                - transaction.id: Transaction identifier (from RequestContext if available)
+                - transaction.name: Transaction name (from RequestContext if available)
+                - tags: Additional tags dictionary (from RequestContext if available)
+                - error.message: Error message (only if exception present)
+                - error.type: Exception type name (only if exception present)
+                - error.stack_trace: Full stack trace (only if exception present)
+        """
+        trace_baggage = record.trace_baggage if isinstance(record.trace_baggage, dict) else {}
+        agent_framework_baggage = record.agent_trace_baggage if isinstance(record.agent_trace_baggage, dict) else {}
+        user_id = trace_baggage.get("aion.sender.id", None)
+
+        message = {
+            '@timestamp': datetime.datetime.fromtimestamp(
+                record.created,
+                tz=datetime.timezone.utc
+            ).strftime('%Y-%m-%dT%H:%M:%S') + f'.{int(record.msecs):03d}Z',
+            'clientId': self._client_id,
+            'logLevel': _LOG_LEVEL_MAP.get(record.levelname, record.levelname),
+            'message': record.getMessage(),
+            'logger': record.name,
+            'user.id': user_id,
+
+            # Host & Process metadata
+            'host.name': self._node_name,
+            'process.pid': os.getpid(),
+
+            # Application & trace context
+            'service.name': get_service_name(),
+            "trace.id": record.trace_id,
+            "transaction.id": record.transaction_id,
+            "transaction.name": record.transaction_name,
+            "span.id": record.trace_span_id,
+            "span.name": record.trace_span_name,
+            "parent.span.id": record.trace_parent_span_id,
+
+            "tags": trace_baggage | agent_framework_baggage | {
+                "aion.distribution.id": record.aion_distribution_id,
+                "aion.version.id": record.aion_version_id,
+                "aion.agentEnvironment.id": record.aion_agent_environment_id,
+                "http.method": record.http_request_method,
+                "http.target": record.http_request_target,
+                "a2a.rpc.method": record.a2a_rpc_method,
+                "a2a.taskStatus.state": TaskState.Name(record.a2a_task_status) if record.a2a_task_status is not None else None,
+            },
+        }
+        # Add exception information if present
+        if record.exc_info:
+            exc_type, exc_value, exc_traceback = record.exc_info
+            message.update({
+                'error.message': str(exc_value) if exc_value else 'Unknown error',
+                'error.type': exc_type.__name__ if exc_type else 'Exception',
+                'error.stack_trace': ''.join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+            })
+
+        return json.dumps(message)

--- a/libs/aion-server/src/aion/server/logging/handlers/logstash/handler.py
+++ b/libs/aion-server/src/aion/server/logging/handlers/logstash/handler.py
@@ -1,0 +1,28 @@
+"""Asynchronous logging handler wiring the Aion formatter, filters and transport."""
+
+from logstash_async.handler import AsynchronousLogstashHandler
+
+from .filter import AionLogstashFilter
+from .formatter import AionLogstashFormatter
+
+__all__ = ["AionLogstashHandler"]
+
+
+class AionLogstashHandler(AsynchronousLogstashHandler):
+    """Asynchronous handler for sending logs to Logstash.
+
+    Automatically configures the handler with AionLogstashFormatter
+    and AionLogstashFilter.
+
+    Args:
+        client_id: Unique identifier for the client.
+        node_name: Name of the node generating the logs.
+        **kwargs: Additional arguments passed to AsynchronousLogstashHandler.
+    """
+
+    def __init__(self, client_id: str, node_name: str, **kwargs):
+        from aion.server.logging.filters import ServerAionContextFilter
+        super().__init__(**kwargs)
+        self.setFormatter(AionLogstashFormatter(client_id=client_id, node_name=node_name))
+        self.addFilter(ServerAionContextFilter())
+        self.addFilter(AionLogstashFilter())

--- a/libs/aion-server/src/aion/server/logging/handlers/logstash/transport.py
+++ b/libs/aion-server/src/aion/server/logging/handlers/logstash/transport.py
@@ -1,0 +1,131 @@
+"""HTTP transport delivering log batches, optionally authenticated with Aion."""
+
+import json
+import logging
+from typing import Optional
+
+import requests
+from logstash_async.transport import HttpTransport
+from requests.auth import HTTPBasicAuth
+
+__all__ = ["AionLogstashTransport"]
+
+logger = logging.getLogger(__name__)
+
+
+class AionLogstashTransport(HttpTransport):
+    """HTTP transport with optional Aion platform authentication.
+
+    When ``use_platform_auth`` is set, every batch is sent with an
+    ``Authorization: Bearer`` header using a token obtained from the Aion
+    platform via the shared JWT manager. While no token can be obtained,
+    batches are dropped silently (a single warning is emitted) so that
+    server logs are not flooded with delivery errors.
+
+    Args:
+        use_platform_auth: Require an Aion platform token for every request.
+        **kwargs: Arguments passed to HttpTransport (host, port, ssl_enable, ...).
+    """
+
+    def __init__(self, *args, use_platform_auth: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._use_platform_auth = use_platform_auth
+        self._token_warning_emitted = False
+
+    def send(self, events: list, **kwargs) -> None:
+        """Send events to the Logstash pipeline.
+
+        Mirrors :meth:`HttpTransport.send`, but attaches an Aion platform
+        Bearer token when platform auth is enabled and skips delivery
+        entirely when the token is not available.
+
+        Args:
+            events: A list of already formatted (JSON string) events.
+        """
+        headers = {'Content-Type': 'application/json'}
+
+        if self._use_platform_auth:
+            token = self._get_platform_token()
+            if not token:
+                self._warn_delivery_skipped(len(events))
+                return
+            headers['Authorization'] = f'Bearer {token}'
+
+        session = requests.Session()
+        try:
+            for batch in self._batches(events):
+                response = session.post(
+                    self.url,
+                    headers=headers,
+                    json=batch,
+                    verify=self._ssl_verify,
+                    timeout=self._timeout,
+                    auth=self._basic_auth())
+                if response.status_code != 200:
+                    response.raise_for_status()
+        finally:
+            session.close()
+
+        if self._token_warning_emitted:
+            self._token_warning_emitted = False
+            logger.info("Logstash delivery resumed after platform token became available.")
+
+    @staticmethod
+    def _get_platform_token() -> Optional[str]:
+        """Return a valid Aion platform token or None when unavailable."""
+        from aion.api.http import aion_jwt_manager
+        return aion_jwt_manager.get_token_sync()
+
+    def _warn_delivery_skipped(self, events_count: int) -> None:
+        """Warn once that events are dropped because no platform token is available."""
+        if self._token_warning_emitted:
+            return
+        self._token_warning_emitted = True
+        logger.warning(
+            "Logstash requires an Aion platform token but none is available; "
+            "dropping %s log event(s). Delivery will resume once "
+            "authentication succeeds.",
+            events_count,
+        )
+
+    def _basic_auth(self) -> Optional[HTTPBasicAuth]:
+        """Return HTTP basic auth credentials when configured, otherwise None."""
+        if self._username is None or self._password is None:
+            return None
+        return HTTPBasicAuth(self._username, self._password)
+
+    def _batches(self, events: list):
+        """Generate dynamic sized batches based on the max content length.
+
+        Reimplements the private ``HttpTransport.__batches`` since it is
+        name-mangled and not accessible to subclasses.
+
+        Args:
+            events: A list of already formatted (JSON string) events.
+        """
+        current_batch = []
+        event_iter = iter(events)
+        while True:
+            try:
+                current_event = next(event_iter)
+            except StopIteration:
+                current_event = None
+                if not current_batch:
+                    return
+                yield current_batch
+            if current_event is None:
+                return
+            if len(current_event) > self._max_content_length:
+                logger.warning(
+                    "The event size <%s> is greater than the max content "
+                    "length <%s>. Skipping event.",
+                    len(current_event), self._max_content_length)
+                continue
+            obj = json.loads(current_event)
+            content_length = len(json.dumps(current_batch + [obj]).encode('utf8'))
+            if content_length > self._max_content_length:
+                batch = current_batch
+                current_batch = [obj]
+                yield batch
+            else:
+                current_batch += [obj]

--- a/libs/aion-server/tests/logging/test_logstash_endpoint.py
+++ b/libs/aion-server/tests/logging/test_logstash_endpoint.py
@@ -1,0 +1,143 @@
+"""Tests for the Logstash endpoint resolver.
+
+Everything about the destination is derived from LOGSTASH_HOST, so these
+tests pin down the derivation: scheme, port and path resolution, and -- most
+importantly -- which hosts are trusted with an Aion platform token.
+"""
+
+import pytest
+
+from aion.server.logging.handlers.logstash.endpoint import (
+    is_platform_host,
+    resolve_logstash_endpoint,
+)
+
+PLATFORM = "api.aion.to"
+
+
+def _resolve(host, port=None, platform_host=PLATFORM):
+    return resolve_logstash_endpoint(host, port, platform_host)
+
+
+class TestNotConfigured:
+    @pytest.mark.parametrize("raw", [None, "", "   "])
+    def test_missing_host_resolves_to_none(self, raw):
+        assert _resolve(raw) is None
+
+
+class TestBareHost:
+    def test_defaults_to_http_and_port_80(self):
+        endpoint = _resolve("logstash.internal")
+        assert endpoint.url == "http://logstash.internal:80/"
+        assert endpoint.use_platform_auth is False
+
+    def test_uses_logstash_port_when_given(self):
+        endpoint = _resolve("localhost", port=5000)
+        assert endpoint.url == "http://localhost:5000/"
+
+    def test_port_embedded_in_host_wins_over_setting(self):
+        endpoint = _resolve("localhost:5044", port=5000)
+        assert endpoint.port == 5044
+
+    def test_bare_platform_host_defaults_to_https(self):
+        endpoint = _resolve("logs.aion.to")
+        assert endpoint.url == "https://logs.aion.to:443/"
+        assert endpoint.use_platform_auth is True
+
+
+class TestUrlHost:
+    def test_full_url_with_path(self):
+        endpoint = _resolve("https://logs.aion.to/ingest")
+        assert endpoint.scheme == "https"
+        assert endpoint.host == "logs.aion.to"
+        assert endpoint.port == 443
+        assert endpoint.path == "ingest"
+        assert endpoint.url == "https://logs.aion.to:443/ingest"
+
+    def test_explicit_port_in_url(self):
+        endpoint = _resolve("https://logs.aion.to:8443/ingest")
+        assert endpoint.port == 8443
+
+    def test_http_url_defaults_to_port_80(self):
+        endpoint = _resolve("http://logstash.internal/in")
+        assert endpoint.port == 80
+        assert endpoint.use_platform_auth is False
+
+    def test_nested_path_is_preserved(self):
+        endpoint = _resolve("https://logs.aion.to/a/b/c")
+        assert endpoint.path == "a/b/c"
+
+    @pytest.mark.parametrize("raw", [
+        "ftp://logs.aion.to",
+        "tcp://logs.aion.to:5044",
+    ])
+    def test_unsupported_scheme_is_rejected(self, raw):
+        with pytest.raises(ValueError, match="unsupported scheme"):
+            _resolve(raw)
+
+    def test_missing_hostname_is_rejected(self):
+        with pytest.raises(ValueError, match="does not contain a hostname"):
+            _resolve("https:///ingest")
+
+    def test_invalid_port_is_rejected(self):
+        with pytest.raises(ValueError, match="invalid port"):
+            _resolve("https://logs.aion.to:not-a-port/")
+
+
+class TestPlatformHostMatching:
+    """The platform token is a full client credential, so this is the
+    security-relevant part: it must never be attached for a foreign host."""
+
+    @pytest.mark.parametrize("host", [
+        "aion.to",
+        "logs.aion.to",
+        "logs.eu.aion.to",
+        "LOGS.AION.TO",
+        "logs.aion.to.",
+    ])
+    def test_platform_hosts_are_recognised(self, host):
+        assert is_platform_host(host, PLATFORM) is True
+
+    @pytest.mark.parametrize("host", [
+        "aion.tools",           # substring match would accept this
+        "aion.torture.com",     # and this
+        "aion.today",
+        "notaion.to",           # suffix without a label boundary
+        "logs.aion.to.evil.com",
+        "attacker.com",
+        "localhost",
+    ])
+    def test_foreign_hosts_are_rejected(self, host):
+        assert is_platform_host(host, PLATFORM) is False
+
+    @pytest.mark.parametrize("host", ["", None])
+    def test_empty_inputs_are_rejected(self, host):
+        assert is_platform_host(host, PLATFORM) is False
+        assert is_platform_host("logs.aion.to", host) is False
+
+    def test_token_is_not_attached_for_foreign_host(self):
+        endpoint = _resolve("https://aion.tools/ingest")
+        assert endpoint.scheme == "https"
+        assert endpoint.use_platform_auth is False
+
+    def test_token_is_not_sent_over_plaintext(self):
+        endpoint = _resolve("http://logs.aion.to/ingest")
+        assert endpoint.use_platform_auth is False
+
+    def test_platform_domain_follows_api_host(self):
+        """A staging environment authenticates without any code change."""
+        endpoint = _resolve("logs.aion.dev", platform_host="api.aion.dev")
+        assert endpoint.use_platform_auth is True
+
+        endpoint = _resolve("logs.aion.to", platform_host="api.aion.dev")
+        assert endpoint.use_platform_auth is False
+
+    def test_no_platform_host_disables_auth(self):
+        endpoint = _resolve("https://logs.aion.to/x", platform_host=None)
+        assert endpoint.use_platform_auth is False
+
+
+class TestDescribe:
+    def test_describe_reports_auth_state(self):
+        assert "platform auth: enabled" in _resolve("https://logs.aion.to").describe()
+        assert "platform auth: disabled" in _resolve("localhost", 5000).describe()

--- a/libs/aion-server/tests/logging/test_logstash_transport.py
+++ b/libs/aion-server/tests/logging/test_logstash_transport.py
@@ -1,0 +1,293 @@
+"""Tests for AionLogstashTransport.
+
+Focus areas:
+  Local mode (use_platform_auth=False):
+    - Sends events without Authorization header
+    - Uses plain HTTP semantics inherited from HttpTransport
+
+  Remote mode (use_platform_auth=True):
+    - Attaches Bearer token from the Aion platform JWT manager
+    - Drops events without any HTTP call when no token is available
+    - Emits the "delivery skipped" warning only once
+    - Resumes delivery and logs recovery once a token becomes available
+
+  Handler wiring:
+    - AionLogstashHandler forwards use_platform_auth to the transport
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aion.server.logging.handlers.logstash import (
+    AionLogstashHandler,
+    AionLogstashTransport,
+)
+
+
+def _make_transport(use_platform_auth: bool) -> AionLogstashTransport:
+    return AionLogstashTransport(
+        host="localhost",
+        port=8081,
+        timeout=5.0,
+        ssl_enable=use_platform_auth,
+        ssl_verify=use_platform_auth,
+        use_platform_auth=use_platform_auth,
+    )
+
+
+def _mock_session():
+    """Return a mocked requests.Session instance with a 200 response."""
+    session = MagicMock()
+    session.post.return_value = MagicMock(status_code=200)
+    return session
+
+
+EVENTS = ['{"message": "event-1"}', '{"message": "event-2"}']
+
+
+class TestLocalMode:
+    def test_sends_without_authorization_header(self):
+        transport = _make_transport(use_platform_auth=False)
+        session = _mock_session()
+
+        with patch(
+            "aion.server.logging.handlers.logstash.transport.requests.Session",
+            return_value=session,
+        ):
+            transport.send(EVENTS)
+
+        session.post.assert_called_once()
+        headers = session.post.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+        assert headers["Content-Type"] == "application/json"
+
+    def test_url_is_plain_http(self):
+        transport = _make_transport(use_platform_auth=False)
+        assert transport.url.startswith("http://")
+
+    def test_does_not_touch_jwt_manager(self):
+        transport = _make_transport(use_platform_auth=False)
+        session = _mock_session()
+
+        with patch(
+            "aion.server.logging.handlers.logstash.transport.requests.Session",
+            return_value=session,
+        ), patch.object(
+            AionLogstashTransport, "_get_platform_token"
+        ) as get_token:
+            transport.send(EVENTS)
+
+        get_token.assert_not_called()
+
+
+class TestRemoteMode:
+    def test_sends_with_bearer_token(self):
+        transport = _make_transport(use_platform_auth=True)
+        session = _mock_session()
+
+        with patch(
+            "aion.server.logging.handlers.logstash.transport.requests.Session",
+            return_value=session,
+        ), patch.object(
+            AionLogstashTransport, "_get_platform_token", return_value="test-token"
+        ):
+            transport.send(EVENTS)
+
+        session.post.assert_called_once()
+        headers = session.post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer test-token"
+
+    def test_url_is_https(self):
+        transport = _make_transport(use_platform_auth=True)
+        assert transport.url.startswith("https://")
+
+    def test_drops_events_without_token(self, caplog):
+        transport = _make_transport(use_platform_auth=True)
+        session = _mock_session()
+
+        with patch(
+            "aion.server.logging.handlers.logstash.transport.requests.Session",
+            return_value=session,
+        ), patch.object(
+            AionLogstashTransport, "_get_platform_token", return_value=None
+        ), caplog.at_level(logging.WARNING):
+            transport.send(EVENTS)
+
+        session.post.assert_not_called()
+        assert any(
+            "requires an Aion platform token" in rec.message for rec in caplog.records
+        )
+
+    def test_warns_only_once_while_token_missing(self, caplog):
+        transport = _make_transport(use_platform_auth=True)
+
+        with patch.object(
+            AionLogstashTransport, "_get_platform_token", return_value=None
+        ), caplog.at_level(logging.WARNING):
+            transport.send(EVENTS)
+            transport.send(EVENTS)
+            transport.send(EVENTS)
+
+        warnings = [
+            rec for rec in caplog.records
+            if "requires an Aion platform token" in rec.message
+        ]
+        assert len(warnings) == 1
+
+    def test_resumes_delivery_after_token_recovery(self, caplog):
+        transport = _make_transport(use_platform_auth=True)
+        session = _mock_session()
+
+        with patch(
+            "aion.server.logging.handlers.logstash.transport.requests.Session",
+            return_value=session,
+        ), caplog.at_level(logging.INFO):
+            with patch.object(
+                AionLogstashTransport, "_get_platform_token", return_value=None
+            ):
+                transport.send(EVENTS)
+
+            with patch.object(
+                AionLogstashTransport, "_get_platform_token", return_value="token"
+            ):
+                transport.send(EVENTS)
+
+        session.post.assert_called_once()
+        assert any("resumed" in rec.message for rec in caplog.records)
+        # Warning flag is reset so a new outage warns again
+        assert transport._token_warning_emitted is False
+
+
+class TestUrl:
+    """The endpoint resolver always supplies a concrete scheme, port and path,
+    so the transport only has to address what it is given."""
+
+    def test_local_url(self):
+        transport = _make_transport(use_platform_auth=False)
+        assert transport.url == "http://localhost:8081/"
+
+    def test_platform_url_with_path(self):
+        transport = AionLogstashTransport(
+            host="logs.aion.to",
+            port=443,
+            path="ingest",
+            ssl_enable=True,
+            use_platform_auth=True,
+        )
+        assert transport.url == "https://logs.aion.to:443/ingest"
+
+    def test_posts_to_resolved_url(self):
+        transport = AionLogstashTransport(
+            host="logs.aion.to",
+            port=443,
+            path="ingest",
+            ssl_enable=True,
+            use_platform_auth=True,
+        )
+        session = _mock_session()
+
+        with patch(
+            "aion.server.logging.handlers.logstash.transport.requests.Session",
+            return_value=session,
+        ), patch.object(
+            AionLogstashTransport, "_get_platform_token", return_value="test-token"
+        ):
+            transport.send(EVENTS)
+
+        assert session.post.call_args.args[0] == "https://logs.aion.to:443/ingest"
+
+
+class TestBatching:
+    def test_splits_oversized_payload_into_batches(self):
+        transport = _make_transport(use_platform_auth=False)
+        transport._max_content_length = 60
+        session = _mock_session()
+
+        events = [
+            '{"message": "batch-a"}',
+            '{"message": "batch-b"}',
+            '{"message": "batch-c"}',
+        ]
+        with patch(
+            "aion.server.logging.handlers.logstash.transport.requests.Session",
+            return_value=session,
+        ):
+            transport.send(events)
+
+        assert session.post.call_count > 1
+        sent = [call.kwargs["json"] for call in session.post.call_args_list]
+        assert [event for batch in sent for event in batch] == [
+            {"message": "batch-a"},
+            {"message": "batch-b"},
+            {"message": "batch-c"},
+        ]
+
+    def test_skips_single_event_larger_than_limit(self):
+        transport = _make_transport(use_platform_auth=False)
+        transport._max_content_length = 10
+        session = _mock_session()
+
+        with patch(
+            "aion.server.logging.handlers.logstash.transport.requests.Session",
+            return_value=session,
+        ):
+            transport.send(['{"message": "way-too-large-event"}'])
+
+        session.post.assert_not_called()
+
+
+class TestHandlerWiring:
+    def test_handler_builds_transport_with_platform_auth(self):
+        handler = AionLogstashHandler(
+            host="localhost",
+            port=8081,
+            database_path=None,
+            transport=AionLogstashTransport,
+            ssl_enable=True,
+            ssl_verify=True,
+            use_platform_auth=True,
+            enable=True,
+            client_id="client-id",
+            node_name="node",
+        )
+
+        assert isinstance(handler._transport, AionLogstashTransport)
+        assert handler._transport._use_platform_auth is True
+        assert handler._transport.url.startswith("https://")
+
+    def test_handler_forwards_path(self):
+        handler = AionLogstashHandler(
+            host="logs.aion.to",
+            port=443,
+            path="ingest",
+            database_path=None,
+            transport=AionLogstashTransport,
+            ssl_enable=True,
+            ssl_verify=True,
+            use_platform_auth=True,
+            enable=True,
+            client_id="client-id",
+            node_name="node",
+        )
+
+        assert handler._transport.url == "https://logs.aion.to:443/ingest"
+
+    def test_handler_builds_transport_local_mode(self):
+        handler = AionLogstashHandler(
+            host="localhost",
+            port=8081,
+            database_path=None,
+            transport=AionLogstashTransport,
+            ssl_enable=False,
+            ssl_verify=False,
+            use_platform_auth=False,
+            enable=True,
+            client_id="client-id",
+            node_name="node",
+        )
+
+        assert isinstance(handler._transport, AionLogstashTransport)
+        assert handler._transport._use_platform_auth is False
+        assert handler._transport.url.startswith("http://")


### PR DESCRIPTION
…he platform

- LOGSTASH_HOST accepts a bare host or a full URL; scheme, port, path and auth are all derived from it, with LOGSTASH_PORT as a fallback
- Platform endpoints are sent an Aion Bearer token, never over plain HTTP; while no token is available delivery is skipped rather than erroring on every batch