### PR TITLE
Upgrade a2a-sdk to 1.1.2; settle tasks interrupted by shutdown

### DIFF
--- a/docs/a2a_extensions/other/stream-delta-handling.md
+++ b/docs/a2a_extensions/other/stream-delta-handling.md
@@ -67,6 +67,16 @@ A streaming chunk is delivered as a `TaskArtifactUpdateEvent`:
     a visual break before the new section.
   - `true` - Append this chunk to the current section for this task and artifact.
 
+  An artifact must be opened before it can be appended to. Sending `append: true`
+  for an `artifactId` that has no previously sent artifact is a protocol
+  violation, and since a2a-sdk 1.1.2 it fails the task with
+  `InvalidAgentResponseError`. Earlier versions logged a warning and silently
+  dropped the chunk, so a graph that emits artifacts in this order used to
+  appear to work while losing content. The built-in LangGraph and ADK adapters
+  always open with `append: false` and are unaffected; this applies to artifacts
+  emitted directly from graph code, for example via `emit_artifact`, which
+  defaults to `append=False`.
+
 - **`lastChunk`**:
   - `false` while more stream events may follow.
   - `true` when the adapter is closing this stream-delta sequence.

--- a/libs/aion-core/pyproject.toml
+++ b/libs/aion-core/pyproject.toml
@@ -12,7 +12,7 @@ pydantic = ">=2.11.3"
 pydantic-settings = ">=2.3.4"
 python-dotenv = ">=1.0.1"
 PyYAML = "^6.0.0"
-a2a-sdk = "1.0.3"
+a2a-sdk = "1.1.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"

--- a/libs/aion-core/src/aion/core/a2a/enums.py
+++ b/libs/aion-core/src/aion/core/a2a/enums.py
@@ -13,6 +13,7 @@ __all__ = [
     "A2AMetadataKey",
     "ArtifactStreamingStatus",
     "ArtifactStreamingStatusReason",
+    "TaskSettlementReason",
 ]
 
 
@@ -58,6 +59,32 @@ class A2AMetadataKey(str, Enum):
     SIGNATURE = "aion:signature"
     NETWORK = "aion:network"
     DISTRIBUTION = "aion:distribution"
+    SETTLED_REASON = "aion:settledReason"
+
+
+class TaskSettlementReason(str, Enum):
+    """Why the server, rather than the agent, decided a task's final state.
+
+    Written to `Task.metadata` under `A2AMetadataKey.SETTLED_REASON` so a client
+    can tell a state the agent declared from one the server had to supply. The
+    reason deliberately lives in metadata rather than in `status.message`: a
+    status message is promoted into task history on the following turn, which
+    would show a resumed agent words it never produced.
+
+    A state is only ever supplied where the execution is known to be gone. A
+    stream that merely ends — because the client disconnected or the turn
+    produced no outcome — is left alone: the execution outlives the subscriber
+    and records the truth itself.
+    """
+
+    SERVER_SHUTDOWN = "server_shutdown"
+    """The server stopped while the task was still running.
+
+    Shutdown cancels the execution, so nothing is left to record an outcome and
+    the task would otherwise stay active in the store forever. It is settled as
+    `INPUT_REQUIRED`: non-active, so the task is no longer presented as running,
+    yet non-terminal, so it can still be resumed.
+    """
 
 
 class ArtifactStreamingStatus(str, Enum):

--- a/libs/aion-server/pyproject.toml
+++ b/libs/aion-server/pyproject.toml
@@ -13,7 +13,7 @@ fastapi = ">=0.115.2"
 pydantic-settings = ">=2.3.4"
 python-dotenv = ">=1.0.1"
 PyYAML = "^6.0.0"
-a2a-sdk = { extras = ["http-server", "telemetry"], version = "1.0.3" }
+a2a-sdk = { extras = ["http-server", "telemetry"], version = "1.1.2" }
 python-logstash-async = "^4.0.1"
 
 aion-core = { git = "https://github.com/Terminal-Research/aion-python-sdk", branch = "main", subdirectory = "libs/aion-core" }

--- a/libs/aion-server/src/aion/server/agent/execution/active_task_registry.py
+++ b/libs/aion-server/src/aion/server/agent/execution/active_task_registry.py
@@ -1,17 +1,40 @@
 """Registry that creates ActiveTask instances wired with AionTaskManager."""
 
-from typing import override
+import logging
+from typing import Any, override
 
 from a2a.server.agent_execution.active_task import ActiveTask
 from a2a.server.agent_execution.active_task_registry import ActiveTaskRegistry
 from a2a.server.context import ServerCallContext
+from a2a.types import Task, TaskState
+from a2a.types.a2a_pb2 import Message
 
+from aion.core.a2a.enums import A2AMetadataKey, TaskSettlementReason
+from aion.server.a2a.constants import NON_ACTIVE_TASK_STATES
 from aion.server.tasks import AionTaskManager, TerminalTaskPushSender
 from aion.server.agent.execution.scope import set_task_manager
 
+logger = logging.getLogger(__name__)
+
 
 class AionActiveTaskRegistry(ActiveTaskRegistry):
-    """Extends the base registry to inject AionTaskManager and populate the execution scope."""
+    """Extends the base registry to inject AionTaskManager and populate the execution scope.
+
+    The registry also settles tasks left running by a shutdown. It is the only
+    layer that may: an outcome is otherwise always written by the execution
+    itself, and the registry is where the execution is known to be gone. A
+    subscriber cannot make that call — it may have merely disconnected while
+    the execution carried on — which is why ``TerminalTaskProjection`` only
+    reads.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Managers are kept here rather than read off ActiveTask so shutdown
+        # can reach the store through the same call context the task ran with:
+        # a store may resolve ownership from it, and no request context exists
+        # at shutdown.
+        self._task_managers: dict[str, AionTaskManager] = {}
 
     @override
     async def get_or_create(
@@ -20,9 +43,37 @@ class AionActiveTaskRegistry(ActiveTaskRegistry):
         call_context: ServerCallContext,
         context_id: str | None = None,
         create_task_if_missing: bool = False,
+        initial_message: Message | None = None,
     ) -> ActiveTask:
-        """Retrieves an existing ActiveTask or creates a new one."""
+        """Retrieves an existing ActiveTask or creates a new one.
+
+        Mirrors the base implementation so that ``AionTaskManager`` can be
+        substituted for the SDK's ``TaskManager`` and the outbound push
+        projection can be bound per task. Because the body is a
+        reimplementation rather than a ``super()`` call, it must track the
+        base signature and preconditions exactly.
+
+        Args:
+            task_id: Identifier of the task to retrieve or create.
+            call_context: Server call context carried into the task manager.
+            context_id: Conversation context the task belongs to, when known.
+            create_task_if_missing: Whether ``ActiveTask.start`` should persist
+                a task that is absent from the store.
+            initial_message: Inbound user message that opened the task. The SDK
+                passes this from ``_setup_active_task`` so the task manager can
+                record it in history; the consumer later de-duplicates it by
+                ``message_id``, so dropping it here would lose the user turn.
+
+        Returns:
+            The registered ``ActiveTask`` for ``task_id``.
+
+        Raises:
+            RuntimeError: If the registry has already been closed via
+                ``aclose()``.
+        """
         async with self._lock:
+            if self._closed:
+                raise RuntimeError('ActiveTaskRegistry is closed')
             if task_id in self._active_tasks:
                 return self._active_tasks[task_id]
 
@@ -30,7 +81,7 @@ class AionActiveTaskRegistry(ActiveTaskRegistry):
                 task_id=task_id,
                 context_id=context_id,
                 task_store=self._task_store,
-                initial_message=None,
+                initial_message=initial_message,
                 context=call_context,
             )
 
@@ -51,9 +102,69 @@ class AionActiveTaskRegistry(ActiveTaskRegistry):
                 on_cleanup=self._on_active_task_cleanup,
             )
             self._active_tasks[task_id] = active_task
+            self._task_managers[task_id] = task_manager
 
         await active_task.start(
             call_context=call_context,
             create_task_if_missing=create_task_if_missing,
         )
         return active_task
+
+    @override
+    async def _remove_task(self, task_id: str) -> None:
+        """Drop the task manager alongside the base registry's own entry."""
+        await super()._remove_task(task_id)
+        async with self._lock:
+            self._task_managers.pop(task_id, None)
+
+    @override
+    async def aclose(self) -> None:
+        """Drain the registry, then settle whatever the shutdown interrupted.
+
+        Draining cancels the producer and consumer of every active task. That
+        cancellation is a ``BaseException``, so neither the producer's nor the
+        consumer's failure handling runs and a task caught mid-turn keeps
+        whatever active state it had. Nothing is left to correct it — the
+        execution is gone — so the task would be presented as running forever.
+
+        Such a task is settled as ``INPUT_REQUIRED``, marked in metadata with
+        ``SERVER_SHUTDOWN``: non-active, so it stops looking alive, but not
+        terminal, so a client can still resume it once the server is back.
+        """
+        async with self._lock:
+            task_managers = list(self._task_managers.values())
+
+        await super().aclose()
+
+        for task_manager in task_managers:
+            try:
+                await self._settle_interrupted_task(task_manager)
+            except Exception as exc:
+                logger.error(
+                    "Failed to settle task %s after shutdown",
+                    task_manager.task_id,
+                    exc_info=exc,
+                )
+
+        async with self._lock:
+            self._task_managers.clear()
+
+    @staticmethod
+    async def _settle_interrupted_task(task_manager: AionTaskManager) -> None:
+        """Mark a single task as interrupted by shutdown, if it is still active."""
+        task = await task_manager.get_task()
+        if task is None or task.status.state in NON_ACTIVE_TASK_STATES:
+            return
+
+        logger.info(
+            "Settling task %s left in %s by shutdown",
+            task.id,
+            TaskState.Name(task.status.state),
+        )
+        settled = Task()
+        settled.CopyFrom(task)
+        settled.status.state = TaskState.TASK_STATE_INPUT_REQUIRED
+        settled.metadata[A2AMetadataKey.SETTLED_REASON.value] = (
+            TaskSettlementReason.SERVER_SHUTDOWN.value
+        )
+        await task_manager.save_task_event(settled)

--- a/libs/aion-server/src/aion/server/agent/execution/request_executor.py
+++ b/libs/aion-server/src/aion/server/agent/execution/request_executor.py
@@ -16,7 +16,6 @@ from a2a.utils.telemetry import trace_function
 from aion.core.runtime import AionRuntimeContextBuilder
 from aion.core.runtime.context.registry import AionRuntimeContextRegistry
 from aion.server.a2a.constants import TERMINAL_TASK_STATES
-from aion.server.a2a.utils import is_task_interrupted
 from aion.server.agent.aion_agent import AionAgent
 from aion.server.agent.execution.scope import set_task_id
 from aion.server.files.a2a import A2AFileTransformer
@@ -58,7 +57,11 @@ class AionAgentRequestExecutor(AgentExecutor):
         if error:
             raise InvalidParamsError()
 
-        task, is_new_task = await self._get_task_for_execution(context)
+        execution = await self._get_task_for_execution(context)
+        if execution is None:
+            return
+
+        task, is_new_task = execution
         self._task_updater = TaskUpdater(event_queue, task.id, task.context_id)
 
         if is_new_task:
@@ -144,34 +147,47 @@ class AionAgentRequestExecutor(AgentExecutor):
             await AionRuntimeContextRegistry.aset_current_context(runtime_context)
 
     @staticmethod
-    async def _get_task_for_execution(context: RequestContext) -> Tuple[Task, bool]:
-        """Get or create a task for execution.
+    async def _get_task_for_execution(context: RequestContext) -> Optional[Tuple[Task, bool]]:
+        """Decide what this request should execute, if anything.
 
-        Logic:
-        1. If current_task exists and is interrupted -> resume it
-        2. If current_task exists but not interrupted -> error
-        3. If no current_task -> create new task
+        An existing task is continued whenever it is not terminal. That covers
+        both an interrupted task, which resumes where it stopped, and one that
+        is still active, which the SDK reaches by dequeuing a second request
+        for the same task: ``ActiveTask`` serialises requests through
+        ``_request_queue`` and treats a follow-up message as the next turn, not
+        as an error. Whether continuing means resuming a suspended run or
+        simply taking another turn is the framework adapter's decision, not
+        this executor's.
+
+        A terminal task is not executed. Reaching one here is a narrow race
+        rather than the normal path — the SDK already rejects a terminal task
+        in ``ActiveTask.start`` and in ``subscribe``, and shuts the request
+        queue down once a terminal state is consumed. The race is that the
+        producer takes a request off the queue before that shutdown lands. The
+        request is dropped silently instead of raising, because an exception
+        out of ``execute`` is not a per-request rejection: the SDK producer
+        reads it as agent failure, persists FAILED for the whole task and
+        propagates the error to every subscriber.
 
         Args:
             context: Request context with optional current task
 
         Returns:
-            Tuple of (task, is_new_task)
-
-        Raises:
-            InvalidParamsError: if task is in a terminal state
+            Tuple of (task, is_new_task), or None when there is nothing to run.
         """
         current_task = context.current_task
 
         if current_task is not None:
-            if is_task_interrupted(current_task):
-                context.current_task = current_task
-                return current_task, False
-            else:
-                raise InvalidParamsError(
-                    message=f"Task {current_task.id} is in terminal state: "
-                            f"{current_task.status.state}"
+            if current_task.status.state in TERMINAL_TASK_STATES:
+                logger.warning(
+                    "Skipping request for task %s already in terminal state %s",
+                    current_task.id,
+                    current_task.status.state,
                 )
+                return None
+
+            context.current_task = current_task
+            return current_task, False
 
         # Create new task
         task = new_task_from_user_message(context.message)

--- a/libs/aion-server/src/aion/server/core/app/factory.py
+++ b/libs/aion-server/src/aion/server/core/app/factory.py
@@ -5,7 +5,7 @@ database, plugins, agent, and FastAPI application using dependency injection.
 """
 import logging
 
-from a2a.server.routes import create_agent_card_routes
+from a2a.server.routes import add_a2a_routes_to_fastapi, create_agent_card_routes
 from a2a.utils.constants import DEFAULT_RPC_URL
 from aion.db.postgres import DbFactory
 from aion.server.agent.aion_agent import AionAgent
@@ -75,6 +75,7 @@ class AppFactory:
 
         self.fastapi_app: Optional[FastAPI] = None
         self._executor: Optional[AionAgentRequestExecutor] = None
+        self._request_handler: Optional[AionRequestHandler] = None
 
     async def initialize(self):
         """Initialize the application factory.
@@ -121,18 +122,26 @@ class AppFactory:
             raise RuntimeError("Application is already created")
 
         request_handler = await self._create_request_handler()
+        self._request_handler = request_handler
 
         jsonrpc_dispatcher = AionJsonRpcDispatcher(
             request_handler=request_handler,
             enable_v0_3_compat=True,
         )
-        routes = [
-            *create_agent_card_routes(self.aion_agent.card),
-            Route(DEFAULT_RPC_URL, endpoint=jsonrpc_dispatcher.handle_requests, methods=['POST']),
-        ]
-
         lifespan = AppLifespan(app_factory=self)
-        self.fastapi_app = FastAPI(routes=routes, lifespan=lifespan.executor)
+        self.fastapi_app = FastAPI(lifespan=lifespan.executor)
+
+        # Registered through the SDK helper rather than FastAPI(routes=...) so
+        # the A2A endpoints are re-wrapped as APIRoute and show up in /docs with
+        # proto-derived request schemas. The routes themselves are unchanged —
+        # JSON-RPC still dispatches through AionJsonRpcDispatcher.
+        add_a2a_routes_to_fastapi(
+            self.fastapi_app,
+            agent_card_routes=create_agent_card_routes(self.aion_agent.card),
+            jsonrpc_routes=[
+                Route(DEFAULT_RPC_URL, endpoint=jsonrpc_dispatcher.handle_requests, methods=['POST']),
+            ],
+        )
         AionExtraHTTPRoutes(self.aion_agent).register(self.fastapi_app)
         self._add_extra_middlewares()
 
@@ -170,6 +179,18 @@ class AppFactory:
     async def shutdown(self) -> None:
         """Shutdown the application and cleanup resources."""
         logger.info("Shutting down application factory")
+
+        # Drain in-flight tasks before the resources they hold are torn down.
+        # The SDK spawns a producer and a consumer asyncio.Task per active task;
+        # without this they survive until event-loop shutdown and surface as
+        # "Task was destroyed but it is pending!", still writing to a task store
+        # and plugins that the steps below are about to close.
+        if self._request_handler is not None:
+            try:
+                await self._request_handler.aclose()
+                logger.info("Active tasks drained")
+            except Exception as exc:
+                logger.error("Error draining active tasks", exc_info=exc)
 
         if self._executor is not None:
             try:

--- a/libs/aion-server/src/aion/server/core/app/handlers/terminal_task_projection.py
+++ b/libs/aion-server/src/aion/server/core/app/handlers/terminal_task_projection.py
@@ -22,17 +22,29 @@ class TerminalTaskProjection:
     event — the complete ``Task``.
 
     This projection bridges the two. It withholds non-active status updates and
-    emits the stored ``Task`` once the source stream is exhausted, and it closes
-    every other way a stream can end:
+    emits the stored ``Task`` once the source stream is exhausted, however the
+    stream ended:
 
-    * the agent never reached a non-active state — the snapshot is closed as
-      ``COMPLETED``, since nothing reported a failure;
-    * the agent raised — the snapshot is closed as ``FAILED`` and the stream
-      ends normally, because a failure is a terminal state the client is
-      entitled to receive as a Task. Only a request that never got as far as
+    * the agent declared an outcome — the SDK consumer persists it before the
+      event reaches this projection, so the stored snapshot already carries it;
+    * the stream raised — the SDK persists FAILED on both the producer and the
+      consumer path before the exception is handed to subscribers, so again the
+      stored snapshot carries it. Only a request that never got as far as
       creating a task propagates the error to the transport;
-    * the task produced events but is missing from the store — the stream fails,
-      because a snapshot whose id resolves to nothing is worse than an error.
+    * the stream ended without an outcome — the stored snapshot is emitted as
+      it stands, active state and all.
+
+    That last case is the reason this projection never writes. A subscriber
+    cannot tell a finished turn from its own disconnection: ``ActiveTask``
+    absorbs the cancellation and ends the subscription normally either way. But
+    a disconnected client does not stop the execution, which keeps running and
+    records the real outcome itself. Inventing a non-active state here would
+    race that writer, and on the resubscribe path it would let an observer
+    settle a task that is merely being watched. A turn that ends with the task
+    still active is legitimate for the SDK — the task simply stays resumable —
+    so the honest close is the snapshot as stored. The one place a state has to
+    be supplied is a shutdown, where the execution is known to be dead; that is
+    done by the active task registry, which owns the lifecycle.
 
     A standalone ``Message`` needs no handling here: Aion's executor always
     announces a Task first, so the SDK consumer is in task mode and rejects a
@@ -104,7 +116,10 @@ class TerminalTaskProjection:
             yield failed
             return
 
-        final_task = await self._close_snapshot(TaskState.TASK_STATE_COMPLETED)
+        # A withheld event names the outcome the agent declared; a stream that
+        # ended silently declares nothing, and the stored snapshot stands.
+        expected_state = self._withheld.status.state if self._withheld is not None else None
+        final_task = await self._close_snapshot(expected_state)
         if final_task is not None:
             yield final_task
         elif self._task_id:
@@ -144,16 +159,23 @@ class TerminalTaskProjection:
         logger.debug("Opening the stream for task %s with a Task snapshot", self._task_id)
         return self._task_transform(task) if self._task_transform else task
 
-    async def _close_snapshot(self, fallback_state: TaskState) -> Task | None:
-        """Load the stored task and make sure it carries a non-active state.
+    async def _close_snapshot(self, expected_state: Optional[TaskState]) -> Task | None:
+        """Load the Task the stream should close with.
 
-        A task still in an active state means the stream ended without the agent
-        declaring an outcome. The projection settles it with ``fallback_state``
-        and persists that, so a later ``tasks/get`` agrees with what the client
-        was told on the stream.
+        The store is only read. Every outcome a stream can end on is persisted
+        by the SDK before it reaches this projection, so the stored snapshot is
+        the authoritative answer; writing here would race the execution, which
+        outlives a disconnected subscriber.
+
+        ``expected_state`` is what the source stream declared, when it declared
+        anything. Finding the store still active despite a declared outcome
+        means the SDK's write has not landed, which should not happen — the
+        client is answered with the declared state so the stream still closes
+        as non-active, but nothing is persisted and the disagreement is logged.
 
         Args:
-            fallback_state: State to settle on when the task is still active.
+            expected_state: Non-active state the source stream declared, or
+                None when it ended without declaring one.
 
         Returns:
             The final Task, or None when the store holds no task.
@@ -165,20 +187,19 @@ class TerminalTaskProjection:
         if task is None:
             return None
 
-        if task.status.state not in NON_ACTIVE_TASK_STATES:
+        if expected_state is not None and task.status.state not in NON_ACTIVE_TASK_STATES:
             logger.warning(
-                "Stream for task %s ended in %s, settling it as %s",
+                "Stream for task %s declared %s but the store still holds %s",
                 task.id,
+                TaskState.Name(expected_state),
                 TaskState.Name(task.status.state),
-                TaskState.Name(fallback_state),
             )
-            # Settle a copy: the snapshot that opened this stream may be the
-            # very same object, and it has already been sent to the client.
-            settled = Task()
-            settled.CopyFrom(task)
-            settled.status.state = fallback_state
-            await self._task_store.save(settled, self._call_context)
-            task = settled
+            # Answer from a copy: the snapshot that opened this stream may be
+            # the very same object, and it has already been sent to the client.
+            declared = Task()
+            declared.CopyFrom(task)
+            declared.status.state = expected_state
+            task = declared
 
         return self._task_transform(task) if self._task_transform else task
 

--- a/libs/aion-server/tests/logging/test_logging_utils.py
+++ b/libs/aion-server/tests/logging/test_logging_utils.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aion.server.logging.filters import BASE_RULES, LOGSTASH_OVERRIDES, NamespaceFilter
+from aion.server.logging.filters import BASE_RULES, NamespaceFilter
 
 
 class TestNamespaceFilter:
@@ -52,19 +52,6 @@ class TestNamespaceFilter:
         """Exact namespace name matches (not only prefix)."""
         f = self._filter({"logstash_async": None})
         assert not f.filter(self._record("logstash_async"))
-
-    def test_logstash_overrides_stricter_than_base(self):
-        """LOGSTASH_OVERRIDES raises minimum level compared to BASE_RULES."""
-        logstash_rules = {**BASE_RULES, **LOGSTASH_OVERRIDES}
-        base_filter = NamespaceFilter(BASE_RULES)
-        logstash_filter = NamespaceFilter(logstash_rules)
-
-        for name, override_level in LOGSTASH_OVERRIDES.items():
-            base_level = BASE_RULES.get(name)
-            if base_level is not None and override_level is not None:
-                assert override_level >= base_level, (
-                    f"LOGSTASH_OVERRIDES[{name!r}] should be >= BASE_RULES[{name!r}]"
-                )
 
 
 class TestSetupRootLogger:

--- a/libs/aion-server/tests/unit/agent/test_active_task_registry_shutdown.py
+++ b/libs/aion-server/tests/unit/agent/test_active_task_registry_shutdown.py
@@ -1,0 +1,148 @@
+"""Tests for the shutdown settlement in AionActiveTaskRegistry.
+
+Shutdown cancels every producer and consumer. Cancellation is a
+``BaseException``, so the SDK's own failure handling does not run and a task
+caught mid-turn keeps whatever active state it had, with nothing left alive to
+correct it. The registry is the one layer that may supply a state for it: it
+knows the execution is gone. A subscriber does not — it may have merely
+disconnected — which is why ``TerminalTaskProjection`` only reads.
+"""
+
+import pytest
+from a2a.types import Task, TaskState, TaskStatus
+from unittest.mock import AsyncMock, Mock, patch
+
+from aion.core.a2a.enums import A2AMetadataKey, TaskSettlementReason
+from aion.server.agent.execution.active_task_registry import AionActiveTaskRegistry
+from aion.server.agent.execution.scope import clear_execution_scope, init_execution_scope
+
+TASK_ID = "task-1"
+CONTEXT_ID = "ctx-1"
+
+
+@pytest.fixture
+def anyio_backend():
+    """Run async tests on asyncio only."""
+    return "asyncio"
+
+
+@pytest.fixture
+def execution_scope():
+    """Provides the execution scope the registry stores the task manager in."""
+    init_execution_scope()
+    yield
+    clear_execution_scope()
+
+
+def _task(state: TaskState) -> Task:
+    return Task(id=TASK_ID, context_id=CONTEXT_ID, status=TaskStatus(state=state))
+
+
+async def _registry_holding(state: TaskState):
+    """Build a registry with one registered task whose store reports ``state``."""
+    store = AsyncMock()
+    store.get.return_value = _task(state)
+    registry = AionActiveTaskRegistry(
+        agent_executor=Mock(),
+        task_store=store,
+        push_sender=None,
+    )
+
+    with patch(
+        "aion.server.agent.execution.active_task_registry.ActiveTask"
+    ) as active_task_cls:
+        active_task_cls.return_value.start = AsyncMock()
+        active_task_cls.return_value.aclose = AsyncMock()
+        await registry.get_or_create(
+            TASK_ID,
+            call_context=Mock(),
+            context_id=CONTEXT_ID,
+        )
+
+    return registry, store, active_task_cls.return_value
+
+
+def _settled(store: AsyncMock) -> Task:
+    store.save.assert_awaited_once()
+    return store.save.await_args.args[0]
+
+
+class TestShutdownSettlement:
+    @pytest.mark.anyio
+    async def test_active_task_is_settled_as_input_required(self, execution_scope):
+        """A task the shutdown interrupted must stop being presented as running."""
+        registry, store, _ = await _registry_holding(TaskState.TASK_STATE_WORKING)
+
+        await registry.aclose()
+
+        assert _settled(store).status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+
+    @pytest.mark.anyio
+    async def test_settled_task_stays_resumable(self, execution_scope):
+        """The supplied state is not terminal, so a client can continue the task."""
+        registry, store, _ = await _registry_holding(TaskState.TASK_STATE_WORKING)
+
+        await registry.aclose()
+
+        assert _settled(store).status.state not in (
+            TaskState.TASK_STATE_COMPLETED,
+            TaskState.TASK_STATE_CANCELED,
+            TaskState.TASK_STATE_FAILED,
+            TaskState.TASK_STATE_REJECTED,
+        )
+
+    @pytest.mark.anyio
+    async def test_settlement_records_its_reason(self, execution_scope):
+        """A client must be able to tell a supplied state from a declared one."""
+        registry, store, _ = await _registry_holding(TaskState.TASK_STATE_WORKING)
+
+        await registry.aclose()
+
+        reason = _settled(store).metadata[A2AMetadataKey.SETTLED_REASON.value]
+        assert reason == TaskSettlementReason.SERVER_SHUTDOWN.value
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("state", [
+        TaskState.TASK_STATE_COMPLETED,
+        TaskState.TASK_STATE_FAILED,
+        TaskState.TASK_STATE_CANCELED,
+        TaskState.TASK_STATE_REJECTED,
+        TaskState.TASK_STATE_INPUT_REQUIRED,
+        TaskState.TASK_STATE_AUTH_REQUIRED,
+    ])
+    async def test_non_active_task_is_left_alone(self, execution_scope, state):
+        """A task that already reached an outcome needs nothing supplied."""
+        registry, store, _ = await _registry_holding(state)
+
+        await registry.aclose()
+
+        store.save.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_base_drain_still_runs(self, execution_scope):
+        """Settling is additive: the SDK's own teardown must happen first."""
+        registry, _, active_task = await _registry_holding(TaskState.TASK_STATE_WORKING)
+
+        await registry.aclose()
+
+        active_task.aclose.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_failed_settlement_does_not_abort_shutdown(self, execution_scope):
+        """A store that refuses the write must not leave the server unable to stop."""
+        registry, store, _ = await _registry_holding(TaskState.TASK_STATE_WORKING)
+        store.save.side_effect = RuntimeError("store is gone")
+
+        await registry.aclose()
+
+        store.save.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_finished_task_is_no_longer_tracked(self, execution_scope):
+        """A task cleaned up during the run must not be revisited at shutdown."""
+        registry, store, _ = await _registry_holding(TaskState.TASK_STATE_WORKING)
+
+        await registry._remove_task(TASK_ID)
+        await registry.aclose()
+
+        store.save.assert_not_awaited()

--- a/libs/aion-server/tests/unit/agent/test_request_executor.py
+++ b/libs/aion-server/tests/unit/agent/test_request_executor.py
@@ -125,6 +125,70 @@ class TestExecuteRuntimeContext:
                         MockRegistry.aset_current_context.assert_not_awaited()
 
 
+class TestTaskForExecution:
+    """The gate that decides what a request executes.
+
+    A task is continued whenever it is not terminal: the SDK serialises
+    requests per task and treats a follow-up message as the next turn, so an
+    active task must not be rejected. A terminal task is skipped rather than
+    raised on, because an exception out of execute() fails the whole task in
+    the SDK producer instead of rejecting the single request.
+    """
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("state", [
+        TaskState.TASK_STATE_INPUT_REQUIRED,
+        TaskState.TASK_STATE_AUTH_REQUIRED,
+        TaskState.TASK_STATE_WORKING,
+        TaskState.TASK_STATE_SUBMITTED,
+    ])
+    async def test_non_terminal_task_is_continued(self, executor, state):
+        task = _make_task(state=state)
+        ctx = _make_context(task=task)
+
+        assert await executor._get_task_for_execution(ctx) == (task, False)
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("state", [
+        TaskState.TASK_STATE_COMPLETED,
+        TaskState.TASK_STATE_CANCELED,
+        TaskState.TASK_STATE_FAILED,
+        TaskState.TASK_STATE_REJECTED,
+    ])
+    async def test_terminal_task_is_skipped(self, executor, state):
+        ctx = _make_context(task=_make_task(state=state))
+
+        assert await executor._get_task_for_execution(ctx) is None
+
+    @pytest.mark.anyio
+    async def test_missing_task_is_created(self, executor):
+        ctx = _make_context(task=None)
+        ctx.message = MagicMock()
+        ctx.metadata = None
+        init_execution_scope()
+
+        with patch(
+            "aion.server.agent.execution.request_executor.new_task_from_user_message"
+        ) as make_task:
+            make_task.return_value = _make_task(state=TaskState.TASK_STATE_SUBMITTED)
+            result = await executor._get_task_for_execution(ctx)
+
+        assert result == (make_task.return_value, True)
+
+    @pytest.mark.anyio
+    async def test_execute_on_terminal_task_runs_nothing(self, executor, event_queue):
+        """A skipped request must not raise: the SDK reads that as agent failure."""
+        executor.agent.stream = MagicMock()
+        executor.agent.resume = MagicMock()
+        ctx = _make_context(task=_make_task(state=TaskState.TASK_STATE_COMPLETED))
+
+        await executor.execute(ctx, event_queue)
+
+        executor.agent.stream.assert_not_called()
+        executor.agent.resume.assert_not_called()
+        event_queue.enqueue_event.assert_not_awaited()
+
+
 class TestCancel:
     @pytest.mark.anyio
     async def test_cancel_missing_task_raises_not_found(self, executor, event_queue):

--- a/libs/aion-server/tests/unit/core/test_app_factory_shutdown.py
+++ b/libs/aion-server/tests/unit/core/test_app_factory_shutdown.py
@@ -1,0 +1,89 @@
+"""Tests for resource teardown ordering in ``AppFactory.shutdown``."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aion.server.core.app.factory import AppFactory
+
+
+@pytest.fixture
+def factory() -> AppFactory:
+    """Builds an AppFactory whose collaborators are all inert mocks.
+
+    Only the shutdown path is under test, so plugins and the database report
+    themselves uninitialised and contribute nothing to the call order.
+    """
+    plugin_factory = Mock()
+    plugin_factory.is_initialized.return_value = False
+    db_factory = Mock()
+    db_factory.is_initialized = False
+
+    return AppFactory(
+        aion_agent=Mock(),
+        db_factory=db_factory,
+        agent_factory=Mock(),
+        plugin_factory=plugin_factory,
+        store_manager=Mock(),
+        upload_manager=Mock(),
+    )
+
+
+async def test_shutdown_drains_active_tasks(factory):
+    """Shutdown must drain the request handler's active tasks.
+
+    The SDK spawns a producer and a consumer ``asyncio.Task`` per active task.
+    Without an explicit drain they outlive the server and surface as
+    ``Task was destroyed but it is pending!``.
+    """
+    factory._request_handler = Mock()
+    factory._request_handler.aclose = AsyncMock()
+
+    await factory.shutdown()
+
+    factory._request_handler.aclose.assert_awaited_once()
+
+
+async def test_shutdown_drains_tasks_before_uploads(factory):
+    """Active tasks must be drained before the resources they use are closed.
+
+    An in-flight task can still emit artifacts, so draining uploads first would
+    race against work the tasks have not finished producing.
+    """
+    call_order: list[str] = []
+
+    factory._request_handler = Mock()
+    factory._request_handler.aclose = AsyncMock(
+        side_effect=lambda: call_order.append("tasks")
+    )
+    factory._executor = Mock()
+    factory._executor.drain = AsyncMock(
+        side_effect=lambda: call_order.append("uploads")
+    )
+
+    await factory.shutdown()
+
+    assert call_order == ["tasks", "uploads"]
+
+
+async def test_shutdown_survives_a_failing_drain(factory):
+    """A drain failure must not abort the remaining teardown steps.
+
+    Shutdown runs from a ``lifespan`` ``finally`` block; letting one failure
+    propagate would skip upload, plugin and database cleanup.
+    """
+    factory._request_handler = Mock()
+    factory._request_handler.aclose = AsyncMock(side_effect=RuntimeError("boom"))
+    factory._executor = Mock()
+    factory._executor.drain = AsyncMock()
+
+    await factory.shutdown()
+
+    factory._executor.drain.assert_awaited_once()
+
+
+async def test_shutdown_without_a_request_handler_is_a_no_op(factory):
+    """Shutting down before the app is built must not raise."""
+    assert factory._request_handler is None
+
+    await factory.shutdown()

--- a/libs/aion-server/tests/unit/core/test_terminal_task_projection.py
+++ b/libs/aion-server/tests/unit/core/test_terminal_task_projection.py
@@ -20,6 +20,7 @@ from a2a.utils.errors import InternalError
 from a2a.utils.task import apply_history_length
 from unittest.mock import AsyncMock, Mock
 
+from aion.core.a2a.enums import A2AMetadataKey
 from aion.server.core.app.handlers.terminal_task_projection import TerminalTaskProjection
 
 TASK_ID = "task-1"
@@ -78,11 +79,6 @@ def _store(task: Task | None) -> Mock:
 
 async def _collect(projection: TerminalTaskProjection, *events) -> list:
     return [event async for event in projection.project(_stream(*events))]
-
-
-def _saved(store: Mock) -> Task:
-    store.save.assert_awaited_once()
-    return store.save.await_args.args[0]
 
 
 class TestTerminalTaskProjection:
@@ -188,8 +184,13 @@ class TestTerminalTaskProjection:
             await _collect(projection, _status(TaskState.TASK_STATE_WORKING, _message()))
 
     @pytest.mark.anyio
-    async def test_stale_active_snapshot_is_settled_before_it_is_emitted(self):
-        """A snapshot still in an active state is closed rather than emitted as is."""
+    async def test_stale_active_snapshot_is_answered_with_the_declared_state(self):
+        """A store lagging behind a declared outcome still closes the stream properly.
+
+        The SDK persists an outcome before the event reaches the projection, so
+        this should not happen. If it does, the client is answered with what the
+        stream declared — but the store is left to its owner.
+        """
         store = _store(_task(TaskState.TASK_STATE_WORKING))
         projection = TerminalTaskProjection(task_store=store, call_context=Mock())
 
@@ -199,7 +200,7 @@ class TestTerminalTaskProjection:
         assert [type(event) for event in result] == [Task, Task]
         assert result[0].status.state == TaskState.TASK_STATE_WORKING
         assert result[-1].status.state == TaskState.TASK_STATE_COMPLETED
-        assert _saved(store).status.state == TaskState.TASK_STATE_COMPLETED
+        store.save.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_event_after_non_active_status_releases_it_in_order(self):
@@ -337,7 +338,13 @@ class TestFailureClosing:
 
     @pytest.mark.anyio
     async def test_failure_closes_the_task_and_ends_the_stream(self):
-        """The client is told the task failed instead of getting a broken stream."""
+        """The client is told the task failed instead of getting a broken stream.
+
+        The SDK persists FAILED on both its producer and its consumer path
+        before the exception reaches a subscriber, so the projection only has
+        to read. A store still holding an active state is a lag the client is
+        answered around, not one the projection writes through.
+        """
         store = _store(_task(TaskState.TASK_STATE_WORKING))
         projection = TerminalTaskProjection(task_store=store, call_context=Mock())
 
@@ -345,7 +352,7 @@ class TestFailureClosing:
 
         assert [type(event) for event in result] == [Task, TaskStatusUpdateEvent, Task]
         assert result[-1].status.state == TaskState.TASK_STATE_FAILED
-        assert _saved(store).status.state == TaskState.TASK_STATE_FAILED
+        store.save.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_failure_keeps_a_state_the_agent_already_declared(self):
@@ -385,23 +392,60 @@ class TestFailureClosing:
 
 
 class TestUnsettledStream:
-    """A stream that ends without an outcome is settled as COMPLETED."""
+    """A stream that ends without an outcome is closed on the stored task as is.
+
+    The projection cannot tell a finished turn from its own disconnection —
+    ``ActiveTask`` absorbs the cancellation and ends the subscription normally
+    either way. Since a disconnected client does not stop the execution, which
+    goes on to record the real outcome, inventing a state here would race a
+    live writer. So nothing is invented and nothing is written.
+    """
 
     @pytest.mark.anyio
-    async def test_active_task_is_completed_when_the_stream_ends(self):
-        """Nothing reported a failure, so the task is closed as COMPLETED."""
+    async def test_silent_stream_closes_on_the_stored_task(self):
+        """The stream still ends with a Task, carrying whatever the store holds."""
         store = _store(_task(TaskState.TASK_STATE_WORKING))
         projection = TerminalTaskProjection(task_store=store, call_context=Mock())
 
         result = await _collect(projection, _status(TaskState.TASK_STATE_WORKING, _message()))
 
         assert [type(event) for event in result] == [Task, TaskStatusUpdateEvent, Task]
-        assert result[-1].status.state == TaskState.TASK_STATE_COMPLETED
-        assert _saved(store).status.state == TaskState.TASK_STATE_COMPLETED
+        assert result[-1].status.state == TaskState.TASK_STATE_WORKING
 
     @pytest.mark.anyio
-    async def test_settling_invents_no_message(self):
-        """A silent stream completes without a fabricated answer."""
+    async def test_silent_stream_never_writes(self):
+        """A subscriber ending is not evidence that the execution ended."""
+        store = _store(_task(TaskState.TASK_STATE_WORKING))
+        projection = TerminalTaskProjection(task_store=store, call_context=Mock())
+
+        await _collect(projection, _status(TaskState.TASK_STATE_WORKING))
+
+        store.save.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_silent_stream_invents_no_settlement_reason(self):
+        """Nothing was settled, so nothing claims it was."""
+        store = _store(_task(TaskState.TASK_STATE_WORKING))
+        projection = TerminalTaskProjection(task_store=store, call_context=Mock())
+
+        result = await _collect(projection, _status(TaskState.TASK_STATE_WORKING))
+
+        assert A2AMetadataKey.SETTLED_REASON.value not in result[-1].metadata
+
+    @pytest.mark.anyio
+    async def test_declared_outcome_is_used_and_left_unmarked(self):
+        """A state the agent declared is not an invention, so it carries no reason."""
+        store = _store(_task(TaskState.TASK_STATE_WORKING))
+        projection = TerminalTaskProjection(task_store=store, call_context=Mock())
+
+        result = await _collect(projection, _status(TaskState.TASK_STATE_COMPLETED))
+
+        assert result[-1].status.state == TaskState.TASK_STATE_COMPLETED
+        assert A2AMetadataKey.SETTLED_REASON.value not in result[-1].metadata
+
+    @pytest.mark.anyio
+    async def test_closing_invents_no_message(self):
+        """A silent stream ends without a fabricated answer."""
         stored = _task(TaskState.TASK_STATE_WORKING)
         projection = TerminalTaskProjection(task_store=_store(stored), call_context=Mock())
 

--- a/libs/aion-server/tests/unit/test_sdk_override_parity.py
+++ b/libs/aion-server/tests/unit/test_sdk_override_parity.py
@@ -1,0 +1,217 @@
+"""Contract tests binding Aion's subclasses to the a2a-sdk classes they extend.
+
+Aion overrides a number of a2a-sdk extension points, and several of those
+overrides reimplement the base body rather than delegating to ``super()``.
+That style is deliberate — it is how ``AionTaskManager`` and the per-task push
+projection get injected — but it means an SDK upgrade can silently desynchronise
+the two sides: the base gains a parameter, starts passing it at a call site
+Aion does not control, and the override rejects it at runtime.
+
+The a2a-sdk 1.0.3 to 1.1.2 upgrade produced exactly that failure.
+``DefaultRequestHandlerV2._setup_active_task`` began passing
+``initial_message=`` to ``ActiveTaskRegistry.get_or_create``, which
+``AionActiveTaskRegistry`` did not accept, breaking every ``message/send`` and
+``message/stream`` call. The whole unit suite stayed green, because nothing
+exercised that path with the real registry attached.
+
+These tests close that gap by asserting the coupling directly instead of
+relying on some other test to happen to traverse it.
+"""
+
+import inspect
+
+import pytest
+from a2a.server.agent_execution import AgentExecutor, RequestContextBuilder
+from a2a.server.agent_execution.active_task_registry import ActiveTaskRegistry
+from a2a.server.request_handlers import DefaultRequestHandlerV2
+from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
+from a2a.server.tasks import TaskManager, TaskStore
+from a2a.server.tasks.push_notification_sender import PushNotificationSender
+from a2a.types import Message, Role
+from unittest.mock import AsyncMock, Mock, patch
+
+from aion.server.agent.execution.active_task_registry import AionActiveTaskRegistry
+from aion.server.agent.execution.scope import clear_execution_scope, init_execution_scope
+from aion.server.agent.execution.request_context_builder import AionRequestContextBuilder
+from aion.server.agent.execution.request_executor import AionAgentRequestExecutor
+from aion.server.core.app.handlers.jsonrpc_dispatcher import AionJsonRpcDispatcher
+from aion.server.core.app.handlers.request_handler import AionRequestHandler
+from aion.server.tasks.stores.in_memory_task_store import InMemoryTaskStore
+from aion.server.tasks.stores.postgres_task_store import PostgresTaskStore
+from aion.server.tasks.task_manager import AionTaskManager
+from aion.server.tasks.terminal_push_sender import TerminalTaskPushSender
+
+# (override class, a2a-sdk base class, overridden method) triples that the
+# server depends on. Extend this table whenever a new SDK extension point is
+# subclassed.
+OVERRIDES = [
+    (AionActiveTaskRegistry, ActiveTaskRegistry, "get_or_create"),
+    (AionActiveTaskRegistry, ActiveTaskRegistry, "aclose"),
+    (AionActiveTaskRegistry, ActiveTaskRegistry, "_remove_task"),
+    (AionTaskManager, TaskManager, "process"),
+    (AionRequestHandler, DefaultRequestHandlerV2, "_setup_active_task"),
+    (AionRequestHandler, DefaultRequestHandlerV2, "on_message_send"),
+    (AionRequestHandler, DefaultRequestHandlerV2, "on_message_send_stream"),
+    (AionRequestHandler, DefaultRequestHandlerV2, "on_subscribe_to_task"),
+    (AionJsonRpcDispatcher, JsonRpcDispatcher, "handle_requests"),
+    (AionRequestContextBuilder, RequestContextBuilder, "build"),
+    (AionAgentRequestExecutor, AgentExecutor, "execute"),
+    (AionAgentRequestExecutor, AgentExecutor, "cancel"),
+    (TerminalTaskPushSender, PushNotificationSender, "send_notification"),
+    (InMemoryTaskStore, TaskStore, "save"),
+    (InMemoryTaskStore, TaskStore, "get"),
+    (InMemoryTaskStore, TaskStore, "delete"),
+    (InMemoryTaskStore, TaskStore, "list"),
+    (PostgresTaskStore, TaskStore, "save"),
+    (PostgresTaskStore, TaskStore, "get"),
+    (PostgresTaskStore, TaskStore, "delete"),
+    (PostgresTaskStore, TaskStore, "list"),
+]
+
+
+def _accepts_arbitrary_keywords(signature: inspect.Signature) -> bool:
+    """Reports whether a signature absorbs unknown keyword arguments.
+
+    Args:
+        signature: Signature of the overriding method.
+
+    Returns:
+        True if the signature declares ``**kwargs``, in which case it can
+        absorb any parameter the base class introduces.
+    """
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+
+
+@pytest.mark.parametrize(
+    ("override_cls", "base_cls", "method_name"),
+    OVERRIDES,
+    ids=[f"{o.__name__}.{m}" for o, _, m in OVERRIDES],
+)
+def test_override_accepts_every_base_parameter(override_cls, base_cls, method_name):
+    """Every parameter the SDK base declares must be accepted by the override.
+
+    The SDK calls these methods through the base class, so any parameter the
+    base knows about can arrive at the override. An override that omits one
+    raises ``TypeError`` at request time rather than at import time, which is
+    why this is asserted statically.
+    """
+    base_method = getattr(base_cls, method_name)
+    override_method = getattr(override_cls, method_name)
+
+    assert override_method is not base_method, (
+        f"{override_cls.__name__}.{method_name} no longer overrides "
+        f"{base_cls.__name__}.{method_name}; drop it from OVERRIDES."
+    )
+
+    base_signature = inspect.signature(base_method)
+    override_signature = inspect.signature(override_method)
+
+    if _accepts_arbitrary_keywords(override_signature):
+        return
+
+    missing = set(base_signature.parameters) - set(override_signature.parameters)
+    assert not missing, (
+        f"{override_cls.__name__}.{method_name} does not accept "
+        f"{sorted(missing)}, which {base_cls.__name__}.{method_name} declares. "
+        f"The SDK can pass these, so the override must take them."
+    )
+
+
+@pytest.mark.parametrize(
+    ("override_cls", "base_cls", "method_name"),
+    OVERRIDES,
+    ids=[f"{o.__name__}.{m}" for o, _, m in OVERRIDES],
+)
+def test_override_preserves_positional_parameter_order(
+    override_cls, base_cls, method_name
+):
+    """Shared parameters must keep the base's relative order.
+
+    The SDK passes some of these positionally, so reordering silently binds a
+    value to the wrong parameter instead of raising.
+    """
+    base_signature = inspect.signature(getattr(base_cls, method_name))
+    override_signature = inspect.signature(getattr(override_cls, method_name))
+
+    positional_kinds = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    base_positional = [
+        name
+        for name, parameter in base_signature.parameters.items()
+        if parameter.kind in positional_kinds
+    ]
+    shared_in_override = [
+        name
+        for name, parameter in override_signature.parameters.items()
+        if parameter.kind in positional_kinds and name in base_positional
+    ]
+    expected = [name for name in base_positional if name in shared_in_override]
+
+    assert shared_in_override == expected, (
+        f"{override_cls.__name__}.{method_name} reorders parameters relative to "
+        f"{base_cls.__name__}.{method_name}: expected {expected}, "
+        f"got {shared_in_override}."
+    )
+
+
+@pytest.fixture
+def execution_scope():
+    """Provides the execution scope the registry stores the task manager in."""
+    init_execution_scope()
+    yield
+    clear_execution_scope()
+
+
+async def test_get_or_create_threads_initial_message_into_task_manager(execution_scope):
+    """The inbound user message must reach the task manager that records it.
+
+    ``AionActiveTaskRegistry.get_or_create`` reimplements the base body and so
+    is responsible for forwarding ``initial_message`` itself. Before the 1.1.2
+    upgrade it hardcoded ``None``; the SDK now supplies the real message and
+    de-duplicates it downstream by ``message_id``, so dropping it here loses the
+    user turn from task history rather than failing loudly.
+    """
+    registry = AionActiveTaskRegistry(
+        agent_executor=Mock(),
+        task_store=InMemoryTaskStore(),
+        push_sender=None,
+    )
+    message = Message(message_id="msg-initial", role=Role.ROLE_USER)
+
+    with patch(
+        "aion.server.agent.execution.active_task_registry.ActiveTask"
+    ) as active_task_cls:
+        active_task_cls.return_value.start = AsyncMock()
+        await registry.get_or_create(
+            "task-initial-message",
+            call_context=Mock(),
+            context_id="ctx-initial-message",
+            initial_message=message,
+        )
+
+    bound_manager = active_task_cls.call_args.kwargs["task_manager"]
+    assert bound_manager._initial_message is message
+
+
+async def test_get_or_create_refuses_work_once_registry_is_closed():
+    """A closed registry must not hand out new tasks.
+
+    ``ActiveTaskRegistry.aclose()`` (new in a2a-sdk 1.1.2) marks the registry
+    closed so shutdown can drain it without racing new arrivals. Since the Aion
+    override reimplements ``get_or_create``, it has to honour that flag itself,
+    otherwise a task registered during shutdown is never drained.
+    """
+    registry = AionActiveTaskRegistry(
+        agent_executor=Mock(),
+        task_store=InMemoryTaskStore(),
+        push_sender=None,
+    )
+    await registry.aclose()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        await registry.get_or_create("task-after-close", call_context=Mock())


### PR DESCRIPTION
- AionActiveTaskRegistry.get_or_create accepts initial_message, now passed by DefaultRequestHandlerV2; without it every message/send and message/stream failed. Routes registered via add_a2a_routes_to_fastapi.
- AppFactory.shutdown drains the request handler before tearing down the resources in-flight tasks hold; the registry settles tasks left active as INPUT_REQUIRED with aion:settledReason = server_shutdown.
- TerminalTaskProjection only reads the store: a subscriber cannot tell a finished turn from its own disconnection, and the execution outlives it and records the real outcome.
- Request executor continues any non-terminal task and drops a terminal one with a warning; raising from execute fails the whole task.