### PR TITLE
fix(auth,push): authenticate webhooks and stop latching on non-401 au…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,63 +1,176 @@
 # Repo guidelines
 
-This repository is a monorepo containing multiple projects located primarily under `libs/`.
+This repository is the Aion Python SDK monorepo. Every distributable package
+lives under `libs/`; shared documentation lives under `docs/`, and the
+repo-wide tooling lives in `Makefile` and `scripts/`.
 
-- Whenever you add or modify a subproject, update this file with a brief description so agents can understand its purpose.
+- Whenever you add or modify a subproject, update this file with a brief
+  description so agents can understand its purpose.
+
+## Layering
+
+Packages are layered; a package may only depend on layers below it.
+
+```
+aion-core                        (no internal deps)
+  └── aion-api-client, aion-db
+        └── aion-mcp
+              └── aion-authoring-langgraph / aion-authoring-adk
+        └── aion-server
+              └── aion-server-langgraph / aion-server-adk
+                    └── aion-sdk  (umbrella CLI, framework packages as extras)
+```
+
+Authoring packages are what agent authors import; they must never pull in
+server or plugin machinery. Server packages implement `AgentPluginProtocol`
+and are discovered by `aion-server` at runtime.
 
 ## Projects
 
-- **_cli** – an Aion adaptation of `langgraph-cli` for running a LangGraph production server. Out-of-date, was based on langgraph_cli and langgraph_api. We are now using our own servers.
-- **_langgraph_api** – internal version of the LangGraph API server exposing HTTP routes, middleware, and async workers.
-- **_langgraph_cli** – internal CLI utilities for building Docker images and launching the LangGraph API server.
-- **_langgraph_storage** – in-memory storage backend and queue implementation for local LangGraph operations.
-- **_a2a-template-langgraph** – example implementation of an A2A protocol serving a LangGraph agent.
-- **_agent-workflow** – example implementation of a langgraph project using langgraph_api as a server
-- **aion-sdk** – command line interface for the Aion Python SDK exposing the `aion` entry point. Delegates `aion chat` and headless `aion chat run` requests to the packaged standalone chat UI, sets the Python credential-helper environment for Python-launched chat auth, and leaves interactive chat commands to the npm `aio`/`aion-chat` entrypoints and composer slash commands.
-- **aion-chat-ui** – standalone React/Ink terminal chat UI built with TypeScript. Packaged for `aion-sdk` as the `aion chat` experience and published to npm as `@terminal-research/aion`, which installs the `aio` executable with an `aion-chat` alias. Includes interactive chat, headless one-shot `run`, slash-command request/response mode controls, update prompts with GitHub release-note links, environment-scoped agent source discovery, local session/settings persistence, and WorkOS CLI/device login with npm keyring storage or the Python credential helper supplied by `aion-sdk`.
-- **aion-server** – Google A2A server running a LangGraph agent. Provides task
-  store, agent/plugin lifecycle, FastAPI application, and contract tests for
-  published `aion.yaml` configuration schemas, including compact discovery
-  documents that omit null field metadata. DB management is delegated to
-  `aion-db`. Graphs and HTTP apps are configured via `aion.yaml` and can be
-  dynamically mounted onto the server.
-- **aion-api-client** – provides a low level GraphQL client and a high level
-  `ApiClient` interface for the Aion API. Also owns low-level HTTP/OpenAI-
-  compatible model-service connection helpers, request-scoped model-service
-  principal header injection, and typed control-plane addressing utilities
-  used by framework packages.
-- **aion-core** – shared A2A payloads, runtime context, invocation abstractions,
-  constants, static agent configuration schema parsing/publication (including
-  dedicated secret fields), and logging used across Aion SDK packages.
-  Owns the
-  provider-neutral Distribution/Messaging context hierarchy, reply contract,
-  and representative provider payload fixtures used to verify that contract.
-- **aion-adk** – Google ADK helper package for Aion-backed model
-  configuration. Provides direct authoring helpers such as `aion_lite_llm`.
-- **aion-authoring-adk** – Google ADK authoring toolkit for Aion MCP access.
-  Provides MCP toolset bindings and request-scoped Aion model helpers without
-  pulling in server plugin machinery.
-- **aion-authoring-langgraph** – LangGraph authoring toolkit for Aion.
-  Provides model helpers, event-routing utilities, streaming helpers, and MCP
-  tool-loading bindings for runtime Aion contexts, including model clients that
-  resolve principal headers at request time, plus provider-neutral immediate
-  context and direct-reply routing. Includes tested Slack distribution examples
-  that resolve provider tools from the incoming runtime capability.
-- **aion-shared** – shared configuration, settings, logging, A2A types, file handling, and utility modules used across Aion Python SDK packages.
-- **aion-mcp** – creates an ASGI proxy for an MCP server defined in
-  `aion.yaml` and provides authenticated remote Aion MCP endpoint helpers for
-  direct capability servers and the control-plane MCP server.
-- **aion-db** – centralized DB management layer (postgres driver, migrations, repositories, models). Exposes the full `aion.db.postgres` namespace: `DbManager`, `DbFactory`, `TaskRecord`, `TaskRecordModel`, `TasksRepository`, Alembic migrations, and utilities (`convert_pg_url`, `verify_connection`, `validate_permissions`). Supports future `aion.db.redis` and similar sub-namespaces. Used by `aion-server` and plugins such as `aion-plugin-adk`.
-- **aion-plugin-adk** – Google ADK control-plane plugin for Aion Server. Adapts
-  inbound A2A requests into ADK execution and maps ADK events back into A2A
-  responses. Model helpers belong in `aion-adk`; MCP authoring helpers belong
-  in `aion-authoring-adk`.
+### Foundation
+
+- **aion-core** — foundation layer with no internal Aion dependencies:
+  A2A protocol models, enums, request/response and artifact types, A2A
+  extension payloads (`cards`, `distribution`, `messaging`, `event`,
+  `traceability`), shared extension URI constants, `aion.yaml` configuration
+  parsing and publication collectors (including dedicated secret fields),
+  invocation abstractions (`card`, `message`, `thread`), the runtime context
+  hierarchy (builder, registry, context extensions), settings
+  (`BaseEnvSettings`, `ApiSettings`), the `DbManagerProtocol` interface,
+  singleton metaclasses, `get_logger()`, and pydantic/text/url/path utilities.
+  Owns the provider-neutral Distribution/Messaging context hierarchy, the
+  reply contract, and the provider payload fixtures that verify it.
+- **aion-api-client** — low-level Aion control-plane access: a websocket
+  GraphQL client generated with `gql` + `ariadne-codegen` (`aion.api.gql`),
+  an HTTP client and JWT manager (`aion.api.http`) that authenticates via
+  `AION_CLIENT_ID`/`AION_CLIENT_SECRET` against `/auth/tokens`, typed
+  control-plane addressing (`aion.api.control_plane`: `CapabilityReference`,
+  `CapabilitySubject`, `PrincipalSelector`, path helpers), and the
+  OpenAI-compatible `model_service_client` with request-scoped
+  model-service principal header injection.
+- **aion-db** — centralized DB management layer under the `aion.db.postgres`
+  namespace: `DbManager`, `DbFactory`, task records/models, repositories,
+  Alembic migrations, custom fields/types, and utilities (`convert_pg_url`,
+  `verify_connection`, `validate_permissions`). Structured so sibling
+  namespaces (`aion.db.redis`, …) can be added later. Used by `aion-server`
+  and server-side framework packages.
+- **aion-mcp** — MCP integration utilities: an ASGI proxy for a local MCP
+  server declared in `aion.yaml` (`proxy.py`) and authenticated remote Aion
+  MCP endpoint builders (`endpoints.py`) for direct capability servers and the
+  control-plane MCP server.
+
+### Server
+
+- **aion-server** — generic A2A server with plugin-based framework support,
+  built on the Google `a2a-sdk` and Starlette/FastAPI. Contains the app
+  factory, lifespan and route registry (`core/app`), middlewares, the
+  platform websocket link (`core/platform`), the agent card/factory and
+  execution adapters (`agent/`), the plugin registry and factory
+  (`plugins/`), task stores, task manager, event deduplicator and push
+  notification senders (`tasks/`), file storage and A2A file handling
+  (`files/`), Aion auth manager and websocket connection services
+  (`services/aion`), OpenTelemetry wiring, logging setup with stream and
+  Logstash handlers, and the proxy server (`aion.proxy`) that fronts multiple
+  agents. Graphs and HTTP apps are configured via `aion.yaml` and can be
+  mounted dynamically; contract tests cover published configuration schemas,
+  including compact discovery documents that omit null field metadata.
+  Push notifications authenticate against external callbacks using the
+  credentials in `taskPushNotificationConfig.authentication` (the a2a-sdk
+  base sender ignores them); delivery timeouts come from
+  `PUSH_NOTIFICATION_TIMEOUT_SECONDS` (httpx's 5s default is too short for a
+  receiver that works before answering). The Logstash endpoint is derived
+  from `LOGSTASH_HOST` (bare host or full URL) with `LOGSTASH_PORT` as a
+  fallback; platform endpoints require an Aion bearer token and are skipped
+  rather than erroring while no token is available. Every outbound stream is
+  closed with a full `Task`; tasks left active at shutdown are settled as
+  `INPUT_REQUIRED` with `aion:settledReason = server_shutdown`. DB management
+  is delegated to `aion-db`.
+- **aion-server-langgraph** — server-side LangGraph integration under
+  `aion.langgraph.server`. Implements `AgentPluginProtocol`/`AgentAdapter`,
+  adapts inbound A2A requests into `graph.astream()` invocations and maps
+  graph output back into A2A messages, tasks and streaming events. Includes
+  execution, checkpointing, state handling, converters, and A2A extension
+  support. Selected with `framework: "langgraph"` in `aion.yaml`; the agent
+  path must resolve to a `StateGraph`, a compiled `Pregel`, or a callable
+  returning one.
+- **aion-server-adk** — server-side Google ADK integration under
+  `aion.adk.server`: `ADKPlugin`/`ADKAdapter`, `ADKExecutor` and
+  `ADKStreamExecutor`, session services (memory and PostgreSQL) via
+  `SessionServiceFactory`, artifact services (memory and A2A-backed) via
+  `ArtifactServiceFactory`, `StateConverter` mapping ADK session state to
+  `ExecutionSnapshot`, and bidirectional A2A ↔ ADK transformers.
+
+### Authoring
+
+- **aion-authoring-langgraph** — LangGraph authoring toolkit under
+  `aion.langgraph.authoring`: `aion_chat_model` and other model helpers that
+  route LangChain/LangGraph calls through Aion's OpenAI-compatible model
+  proxy and resolve principal headers at request time, state and streaming
+  helpers, event-routing utilities, invocation helpers, MCP tool loading, and
+  provider-neutral immediate context and direct-reply routing. Includes
+  tested Slack distribution examples that resolve provider tools from the
+  incoming runtime capability.
+- **aion-authoring-adk** — Google ADK authoring toolkit under
+  `aion.adk.authoring`: MCP toolset bindings, request-scoped Aion model
+  helpers, invocation helpers and transformers, without pulling in server
+  plugin machinery.
+
+### Entry points
+
+- **aion-sdk** — umbrella distribution and CLI exposing the `aion` entry
+  point (`aion serve`, `aion chat`, `aion logs`). `serve` launches all agents
+  declared in `aion.yaml` plus the proxy server with automatic port
+  assignment; `chat` (including headless `aion chat run`) delegates to the
+  standalone chat UI bundled at `src/aion/cli/bin/cli.mjs` and sets the
+  Python credential-helper environment for chat auth. Framework support is
+  opt-in through extras: `langgraph-authoring`, `langgraph-server`,
+  `adk-authoring`, `adk-server`, `all`.
+- **aion-chat-ui** — standalone React/Ink terminal chat UI in TypeScript.
+  Published to npm as `@terminal-research/aion`, which installs the `aio`
+  executable with an `aion-chat` alias, and staged into `aion-sdk` via
+  `npm run stage:python`. Provides interactive chat, headless one-shot `run`,
+  slash-command request/response mode controls, update prompts with GitHub
+  release-note links, environment-scoped agent source discovery, local
+  session/settings persistence, and WorkOS CLI/device login with npm keyring
+  storage or the Python credential helper supplied by `aion-sdk`. See
+  `libs/aion-chat-ui/AGENTS.md` for session-log inspection and package-local
+  conventions.
+
+## Repo tooling
+
+- `make help` lists all targets. `make tests` runs `scripts/tests.py`, which
+  discovers every `libs/aion-*` package with a `tests/` directory and runs
+  `poetry run pytest` inside it (libs without tests are skipped). Target
+  specific packages with `python scripts/tests.py aion-core aion-db`, and use
+  `--fail-fast` to stop at the first failure.
+- Internal packages depend on each other by git reference, not by version, so
+  a shared-dependency bump does not lock against `main`. For cross-package
+  work use `make deps-use-local` (switch to local paths, lock, sync, verify)
+  and `make deps-use-remote` to return. `make deps-set-branch BRANCH=...`
+  repoints git references at a feature branch. `poetry.lock` files are not
+  committed.
+- `.github/workflows/publish-aion.yml` publishes the `aion-chat-ui` npm
+  package on GitHub release.
+
+## Documentation
+
+User-facing docs live in `docs/`: `environment-variables.md`,
+`aion-yaml-config.md`, `multiple-agents.md`, `app-registry.md`,
+`http_endpoints.md`, `a2a_extensions/`, and `development/` (environment and
+dependency workflows). Keep them in sync with behavioural changes.
 
 ## Additional guidelines
 
-1. Libraries in packages whose names start with an underscore are provided only for context and are **not** intended to be distributed.
-2. Always use idiomatic Python and best practices. Use `snake_case` for Python module names, variables, attributes, dataclass fields, function parameters, and keyword arguments; reserve camelCase only for explicit wire-format aliases or protocol field names.
-3. Document all code with detailed Python docstrings in Google's style, especially at the class and method level; avoid overly terse summaries.
-4. Create thourough unit tests for all code using pytest.
-5. For docstring sections that define a group of injected or projected fields,
-   use a hanging-indent aligned definition list: left-align the field names in a
-   fixed-width first column and align descriptions after an em dash.
+1. Always use idiomatic Python and best practices. Use `snake_case` for Python
+   module names, variables, attributes, dataclass fields, function parameters,
+   and keyword arguments; reserve camelCase only for explicit wire-format
+   aliases or protocol field names.
+2. Document all code with detailed Python docstrings in Google's style,
+   especially at the class and method level; avoid overly terse summaries.
+3. Create thorough unit tests for all code using pytest.
+4. For docstring sections that define a group of injected or projected fields,
+   use a hanging-indent aligned definition list: left-align the field names in
+   a fixed-width first column and align descriptions after an em dash.
+5. Respect the layering above: authoring packages stay free of server
+   dependencies, and model helpers belong in the authoring package for their
+   framework rather than in the server plugin.

--- a/libs/aion-api-client/README.md
+++ b/libs/aion-api-client/README.md
@@ -44,7 +44,7 @@ The REST helpers target these control-plane endpoints:
 
 | Endpoint | Purpose |
 |---|---|
-| `POST /auth/token` | Exchanges Aion client credentials for an API token. |
+| `POST /auth/tokens` | Exchanges Aion client credentials for an API token. |
 | `GET /v1/models` | Lists model-service catalog entries available through Aion. |
 | `GET /v1/models/{model}` | Retrieves one model-service catalog entry. |
 | `POST /v1/chat/completions` | Creates a model-service chat completion, including streaming responses when requested. |

--- a/libs/aion-api-client/src/aion/api/exceptions.py
+++ b/libs/aion-api-client/src/aion/api/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 __all__ = [
     "AionException",
     "AionAuthenticationError",
@@ -10,5 +12,16 @@ class AionException(Exception):
 
 
 class AionAuthenticationError(AionException):
-    """Authentication related errors"""
-    pass
+    """Authentication related errors.
+
+    Args:
+        message (str): Human readable description of the failure.
+        status_code (Optional[int]): HTTP status returned by the auth endpoint
+            when the error originated from a response, ``None`` otherwise.
+            Callers use this to tell rejected credentials (401) apart from
+            failures that are worth retrying.
+    """
+
+    def __init__(self, message: str, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code

--- a/libs/aion-api-client/src/aion/api/http/client.py
+++ b/libs/aion-api-client/src/aion/api/http/client.py
@@ -46,7 +46,7 @@ class AionHttpClient:
         """
         response = self.request_sync(
             method="POST",
-            endpoint="/auth/token",
+            endpoint="/auth/tokens",
             token=None,
             json_data=self._authentication_payload(),
         )
@@ -67,10 +67,13 @@ class AionHttpClient:
         response: httpx.Response,
     ) -> Dict[str, Any]:
         if response.status_code == 401:
-            raise AionAuthenticationError("Invalid client credentials")
+            raise AionAuthenticationError(
+                "Invalid client credentials", status_code=401
+            )
         if response.status_code != 200:
             raise AionAuthenticationError(
-                f"Authentication failed: {response.status_code}"
+                f"Authentication failed: {response.status_code}",
+                status_code=response.status_code,
             )
 
         return response.json()

--- a/libs/aion-api-client/src/aion/api/http/jwt_manager.py
+++ b/libs/aion-api-client/src/aion/api/http/jwt_manager.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import jwt
 
@@ -160,6 +160,51 @@ class AionRefreshingJWTManager(AionJWTManager):
                     await self._refresh_token()
             return None if not self._token else self._token.value
 
+    def _store_token(self, data: Dict[str, Any]) -> None:
+        """
+        Cache the token carried by an authentication response.
+
+        Extracts the access token, creates a :class:`Token` from it, and clears
+        the auth-failed latch so a recovered endpoint resumes serving tokens.
+        """
+        token_value = data.get("accessToken")
+        if not token_value:
+            raise ValueError("Access Token is missing in response.")
+
+        first_token = self._token is None
+        self._token = Token.from_jwt(token_value)
+        # Reset auth failed flag on successful authentication
+        self._auth_failed = False
+
+        logger.info(
+            "Token %s successfully, expires at: %s",
+            "fetched" if first_token else "refreshed",
+            self._token.expires_at,
+        )
+
+    def _handle_auth_error(self, ex: AionAuthenticationError) -> None:
+        """
+        Drop the cached token, latching only when credentials were rejected.
+
+        Only a 401 means the credentials themselves are wrong, which no amount
+        of retrying will fix. Every other status - a 404 from a stale endpoint,
+        a 5xx, a gateway error - is transient or a deployment problem, and
+        latching on it would disable authentication for every consumer sharing
+        this manager until the process restarts.
+        """
+        self._token = None
+
+        if ex.status_code == 401:
+            self._auth_failed = True
+            logger.warning(
+                "Aion authentication failed with 401 error. "
+                "Further refresh attempts will be skipped until reset.")
+            return
+
+        logger.warning(
+            "Aion authentication failed: %s. Refresh will be retried on the "
+            "next token request.", ex)
+
     async def _refresh_token(self) -> None:
         """
         Refresh the token using the HTTP client.
@@ -177,33 +222,11 @@ class AionRefreshingJWTManager(AionJWTManager):
         if self._auth_failed:
             return
 
-        first_token = self._token is None
         try:
-            data = await self._client.authenticate()
-            token_value = data.get("accessToken")
-            if not token_value:
-                raise ValueError("Access Token is missing in response.")
+            self._store_token(await self._client.authenticate())
 
-            self._token = Token.from_jwt(token_value)
-            # Reset auth failed flag on successful authentication
-            self._auth_failed = False
-
-            if first_token:
-                processed_action = "fetched"
-            else:
-                processed_action = "refreshed"
-            logger.info(
-                "Token %s successfully, expires at: %s",
-                processed_action,
-                self._token.expires_at,
-            )
-
-        except AionAuthenticationError:
-            self._auth_failed = True
-            self._token = None
-            logger.warning(
-                "Aion authentication failed with 401 error. "
-                "Further refresh attempts will be skipped until reset.")
+        except AionAuthenticationError as ex:
+            self._handle_auth_error(ex)
 
         except Exception as ex:
             logger.error("Token refresh failed: %s", ex)
@@ -236,32 +259,11 @@ class AionRefreshingJWTManager(AionJWTManager):
         if self._auth_failed:
             return
 
-        first_token = self._token is None
         try:
-            data = self._client.authenticate_sync()
-            token_value = data.get("accessToken")
-            if not token_value:
-                raise ValueError("Access Token is missing in response.")
+            self._store_token(self._client.authenticate_sync())
 
-            self._token = Token.from_jwt(token_value)
-            self._auth_failed = False
-
-            if first_token:
-                processed_action = "fetched"
-            else:
-                processed_action = "refreshed"
-            logger.info(
-                "Token %s successfully, expires at: %s",
-                processed_action,
-                self._token.expires_at,
-            )
-
-        except AionAuthenticationError:
-            self._auth_failed = True
-            self._token = None
-            logger.warning(
-                "Aion authentication failed with 401 error. "
-                "Further refresh attempts will be skipped until reset.")
+        except AionAuthenticationError as ex:
+            self._handle_auth_error(ex)
 
         except Exception as ex:
             logger.error("Token refresh failed: %s", ex)

--- a/libs/aion-api-client/tests/test_jwt_auth_state.py
+++ b/libs/aion-api-client/tests/test_jwt_auth_state.py
@@ -1,0 +1,180 @@
+"""Tests for authentication endpoints and auth-failure latching."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+os.environ.setdefault("AION_CLIENT_ID", "test-client")
+os.environ.setdefault("AION_CLIENT_SECRET", "test-secret")
+
+import pytest
+
+pytest.importorskip("httpx")
+pytest.importorskip("jwt")
+
+from aion.api.exceptions import AionAuthenticationError
+from aion.api.http.client import AionHttpClient
+from aion.api.http.jwt_manager import AionRefreshingJWTManager
+
+AUTH_ENDPOINT = "/auth/tokens"
+
+
+@pytest.fixture(autouse=True)
+def credentials(monkeypatch):
+    """Give the auth payload builder credentials to work with.
+
+    ``api_settings`` is a singleton built when ``aion.core.settings`` is first
+    imported, so setting environment variables at module scope only works when
+    this module happens to be imported first. Patch the instance instead.
+    """
+    from aion.core.settings import api_settings
+
+    monkeypatch.setattr(api_settings, "client_id", "test-client")
+    monkeypatch.setattr(api_settings, "client_secret", "test-secret")
+
+
+class RecordingHttpClient(AionHttpClient):
+    """AionHttpClient that records requests instead of sending them."""
+
+    def __init__(self, status_code: int = 200, token: str | None = None) -> None:
+        super().__init__()
+        self.status_code = status_code
+        self.token = token
+        self.endpoints: list[str] = []
+
+    def _respond(self, endpoint: str):
+        import httpx
+
+        self.endpoints.append(endpoint)
+        return httpx.Response(
+            status_code=self.status_code,
+            json={"accessToken": self.token} if self.token else {},
+        )
+
+    async def request(self, method: str, endpoint: str, *args, **kwargs):
+        return self._respond(endpoint)
+
+    def request_sync(self, method: str, endpoint: str, *args, **kwargs):
+        return self._respond(endpoint)
+
+
+class FailingClient:
+    """Auth client that always fails with a fixed status code."""
+
+    def __init__(self, status_code: int | None) -> None:
+        self.status_code = status_code
+
+    def _fail(self):
+        raise AionAuthenticationError(
+            f"Authentication failed: {self.status_code}",
+            status_code=self.status_code,
+        )
+
+    async def authenticate(self):
+        self._fail()
+
+    def authenticate_sync(self):
+        self._fail()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_authenticate_uses_tokens_endpoint(valid_jwt_token) -> None:
+    """The async auth call should target the canonical endpoint."""
+    client = RecordingHttpClient(token=valid_jwt_token)
+
+    await client.authenticate()
+
+    assert client.endpoints == [AUTH_ENDPOINT]
+
+
+def test_authenticate_sync_uses_same_endpoint_as_async(valid_jwt_token) -> None:
+    """Sync and async auth must not drift onto different endpoints.
+
+    They did once: the move to ``/auth/tokens`` updated only the async call and
+    left the sync one on ``/auth/token``, which 404s. That killed every
+    synchronous consumer (model service, MCP, remote logstash) while the async
+    path kept working, so nothing pointed at the endpoint as the cause.
+    """
+    client = RecordingHttpClient(token=valid_jwt_token)
+
+    client.authenticate_sync()
+
+    assert client.endpoints == [AUTH_ENDPOINT]
+
+
+def test_authentication_error_carries_status_code() -> None:
+    """Non-200 responses should report the status they actually got."""
+    client = RecordingHttpClient(status_code=404)
+
+    with pytest.raises(AionAuthenticationError) as excinfo:
+        client.authenticate_sync()
+
+    assert excinfo.value.status_code == 404
+    assert "404" in str(excinfo.value)
+
+
+def test_invalid_credentials_latch_auth_failed() -> None:
+    """A 401 means the credentials are wrong, so refreshing should stop."""
+    manager = AionRefreshingJWTManager()
+    manager._client = FailingClient(401)
+
+    assert manager.get_token_sync() is None
+    assert manager.is_auth_failed is True
+
+
+@pytest.mark.parametrize("status_code", [404, 500, 502, None])
+def test_non_401_failures_do_not_latch(status_code) -> None:
+    """Only rejected credentials are permanent; everything else stays retryable.
+
+    ``_auth_failed`` is shared by every consumer of the global manager, so
+    latching on a 404 or a 5xx would disable authentication process-wide -
+    including callers whose own requests would have succeeded - until restart.
+    """
+    manager = AionRefreshingJWTManager()
+    manager._client = FailingClient(status_code)
+
+    assert manager.get_token_sync() is None
+    assert manager.is_auth_failed is False
+
+
+@pytest.mark.anyio("asyncio")
+async def test_async_path_survives_sync_failure(valid_jwt_token) -> None:
+    """A failed sync refresh must not block a working async one."""
+    manager = AionRefreshingJWTManager()
+    manager._client = FailingClient(404)
+    manager.get_token_sync()
+
+    manager._client = RecordingHttpClient(token=valid_jwt_token)
+
+    assert await manager.get_token() == valid_jwt_token
+
+
+def test_transient_failure_recovers_on_next_request(valid_jwt_token) -> None:
+    """Once the endpoint recovers, the next request should get a token."""
+    manager = AionRefreshingJWTManager()
+    manager._client = FailingClient(503)
+
+    assert manager.get_token_sync() is None
+
+    manager._client = RecordingHttpClient(token=valid_jwt_token)
+
+    assert manager.get_token_sync() == valid_jwt_token
+
+
+def test_successful_refresh_clears_latch(valid_jwt_token) -> None:
+    """A successful authentication should reset a previously latched failure."""
+    manager = AionRefreshingJWTManager()
+    manager._client = FailingClient(401)
+    manager.get_token_sync()
+    assert manager.is_auth_failed is True
+
+    manager.reset_auth_state()
+    manager._client = RecordingHttpClient(token=valid_jwt_token)
+
+    assert manager.get_token_sync() == valid_jwt_token
+    assert manager.is_auth_failed is False

--- a/libs/aion-server/src/aion/server/logging/handlers/logstash/formatter.py
+++ b/libs/aion-server/src/aion/server/logging/handlers/logstash/formatter.py
@@ -90,7 +90,7 @@ class AionLogstashFormatter(LogstashFormatter):
             "span.name": record.trace_span_name,
             "parent.span.id": record.trace_parent_span_id,
 
-            "tags": trace_baggage | agent_framework_baggage | {
+            "_tags": trace_baggage | agent_framework_baggage | {
                 "aion.distribution.id": record.aion_distribution_id,
                 "aion.version.id": record.aion_version_id,
                 "aion.agentEnvironment.id": record.aion_agent_environment_id,

--- a/libs/aion-server/src/aion/server/settings.py
+++ b/libs/aion-server/src/aion/server/settings.py
@@ -23,6 +23,20 @@ class AppSettings(BaseEnvSettings):
         )
     )
 
+    push_notification_timeout_seconds: float = Field(
+        default=30.0,
+        alias="PUSH_NOTIFICATION_TIMEOUT_SECONDS",
+        description=(
+            "Read/write timeout for webhook deliveries, in seconds. The httpx "
+            "default of 5s is too short for a receiver that does real work on the "
+            "callback before answering, which shows up as httpx.ReadTimeout even "
+            "though the request was accepted. Connect timeout stays at 5s: an "
+            "unreachable host should fail fast. Note that the first delivery of a "
+            "run is awaited in the request path, so this value bounds how long a "
+            "slow webhook can delay the message/send response."
+        )
+    )
+
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = Field(
         description="Logging level to use.",
         alias="LOG_LEVEL",

--- a/libs/aion-server/src/aion/server/tasks/__init__.py
+++ b/libs/aion-server/src/aion/server/tasks/__init__.py
@@ -2,6 +2,7 @@ from .stores import BaseTaskStore, PostgresTaskStore, InMemoryTaskStore
 from .store_manager import store_manager, StoreManager
 from .task_manager import AionTaskManager
 from .push_notifications import PushNotificationFactory
+from .authenticated_push_sender import AuthenticatedPushNotificationSender
 from .terminal_push_sender import TerminalTaskPushSender
 from .deduplicator import A2ATaskDeduplicator
 
@@ -15,6 +16,7 @@ __all__ = [
     "AionTaskManager",
     # Push notifications
     "PushNotificationFactory",
+    "AuthenticatedPushNotificationSender",
     "TerminalTaskPushSender",
     "A2ATaskDeduplicator",
 ]

--- a/libs/aion-server/src/aion/server/tasks/authenticated_push_sender.py
+++ b/libs/aion-server/src/aion/server/tasks/authenticated_push_sender.py
@@ -1,0 +1,162 @@
+"""Push-notification sender that authenticates webhook calls against external servers."""
+
+import httpx
+import logging
+from a2a.server.tasks.base_push_notification_sender import BasePushNotificationSender
+from a2a.server.tasks.push_notification_sender import PushNotificationEvent
+from a2a.types.a2a_pb2 import TaskPushNotificationConfig
+from a2a.utils.proto_utils import to_stream_response
+from google.protobuf.json_format import MessageToDict
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_AUTH_SCHEME = 'Bearer'
+RESPONSE_SUMMARY_LIMIT = 200
+
+
+def _summarize(response: httpx.Response) -> str:
+    """Condenses a rejection response body into one loggable line.
+
+    Args:
+        response: The refusal returned by the webhook.
+
+    Returns:
+        The body collapsed onto a single line and truncated, or a placeholder
+        when the body is empty or could not be decoded.
+    """
+    try:
+        body = ' '.join(response.text.split())
+    except Exception:
+        return '<undecodable body>'
+    if not body:
+        return '<empty body>'
+    if len(body) > RESPONSE_SUMMARY_LIMIT:
+        return f'{body[:RESPONSE_SUMMARY_LIMIT]}…'
+    return body
+
+
+class AuthenticatedPushNotificationSender(BasePushNotificationSender):
+    """Applies ``PushNotificationConfig.authentication`` to the outbound webhook call.
+
+    The A2A schema lets a client declare how the receiving server authenticates
+    its callbacks — ``TaskPushNotificationConfig.authentication`` carries a
+    ``scheme``/``credentials`` pair, and the platform populates it when it hands
+    us a callback URL. The store round-trips that field intact, but the SDK's
+    ``BasePushNotificationSender`` only ever emits the legacy
+    ``X-A2A-Notification-Token`` header, so every notification reaches an
+    authenticated endpoint anonymously and is rejected with 401/403.
+
+    This sender restores the missing half: the declared credentials go out as a
+    standard ``Authorization`` header. The notification token keeps its own
+    header, so a config that sets both is delivered with both, and a config that
+    sets neither behaves exactly as it did before.
+
+    The whole dispatch body is reimplemented rather than delegated to, because
+    the base class builds its header dict inline with no extension point.
+    ``test_sdk_override_parity`` pins the override to the base signature so an
+    SDK upgrade that changes it fails at test time rather than at delivery time.
+    """
+
+    async def _dispatch_notification(
+            self,
+            event: PushNotificationEvent,
+            push_info: TaskPushNotificationConfig,
+            task_id: str,
+    ) -> bool:
+        """Posts a single notification to one configured webhook.
+
+        Args:
+            event: The event to deliver, serialized as a stream response.
+            push_info: The stored configuration for this webhook, including the
+                target URL and any declared authentication.
+            task_id: Identifier of the task the event belongs to, for logging.
+
+        Returns:
+            True when the webhook accepted the delivery, False when the request
+            failed. Failures are logged and swallowed, matching the base class:
+            one unreachable webhook must not abort the fan-out to the others.
+        """
+        url = push_info.url
+        try:
+            response = await self._client.post(
+                url,
+                json=MessageToDict(to_stream_response(event)),
+                headers=self._build_headers(push_info) or None,
+            )
+            response.raise_for_status()
+            logger.info(
+                'Push-notification sent for task_id=%s to URL: %s', task_id, url
+            )
+        except httpx.HTTPStatusError as error:
+            # The webhook answered and refused. The status and the receiver's own
+            # message are the whole diagnosis — 401/403 points at the credentials
+            # on the config, 5xx at the receiver — so a stack trace of our call
+            # frames only buries it. The body is what distinguishes a gateway
+            # error from the application's own refusal, and it is truncated
+            # because a receiver may answer with a full HTML page.
+            logger.warning(
+                'Push-notification rejected for task_id=%s by URL: %s — HTTP %s: %s',
+                task_id,
+                url,
+                error.response.status_code,
+                _summarize(error.response),
+            )
+            return False
+        except httpx.TimeoutException as error:
+            # The request went out but the receiver did not answer in time.
+            # Routine for a slow webhook, and tunable via
+            # PUSH_NOTIFICATION_TIMEOUT_SECONDS, so it is reported as a
+            # condition rather than as a crash.
+            logger.warning(
+                'Push-notification timed out for task_id=%s to URL: %s (%s). '
+                'Raise PUSH_NOTIFICATION_TIMEOUT_SECONDS if the receiver is '
+                'expected to be this slow.',
+                task_id,
+                url,
+                type(error).__name__,
+            )
+            return False
+        except Exception:
+            logger.exception(
+                'Error sending push-notification for task_id=%s to URL: %s.',
+                task_id,
+                url,
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _build_headers(push_info: TaskPushNotificationConfig) -> dict[str, str]:
+        """Derives the outbound headers from a stored push configuration.
+
+        Args:
+            push_info: The stored configuration for the target webhook.
+
+        Returns:
+            Mapping of header names to values. Empty when the configuration
+            declares neither a notification token nor credentials.
+
+            X-A2A-Notification-Token  — the opaque token from ``push_info.token``,
+                                        the SDK's own webhook-validation channel.
+            Authorization             — ``"<scheme> <credentials>"`` from
+                                        ``push_info.authentication``, defaulting to
+                                        the Bearer scheme when the client declared
+                                        credentials without naming a scheme.
+
+        Credential values are never logged: an exception raised while sending
+        carries only the task id and the URL.
+        """
+        headers: dict[str, str] = {}
+
+        if push_info.token:
+            headers['X-A2A-Notification-Token'] = push_info.token
+
+        authentication = push_info.authentication
+        if authentication.credentials:
+            scheme = authentication.scheme or DEFAULT_AUTH_SCHEME
+            headers['Authorization'] = f'{scheme} {authentication.credentials}'
+
+        return headers
+
+
+__all__ = ['AuthenticatedPushNotificationSender']

--- a/libs/aion-server/src/aion/server/tasks/push_notifications.py
+++ b/libs/aion-server/src/aion/server/tasks/push_notifications.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import httpx
 from a2a.server.tasks import InMemoryPushNotificationConfigStore
-from a2a.server.tasks.base_push_notification_sender import BasePushNotificationSender
 from a2a.server.tasks.push_notification_config_store import PushNotificationConfigStore
 from a2a.server.tasks.push_notification_sender import PushNotificationSender
 from aion.db.postgres import AION_SCHEMA
 from aion.core.db import DbManagerProtocol
 from typing import Optional
+
+from aion.server.settings import app_settings
+from .authenticated_push_sender import AuthenticatedPushNotificationSender
+
+CONNECT_TIMEOUT_SECONDS = 5.0
 
 
 class PushNotificationFactory:
@@ -29,11 +33,35 @@ class PushNotificationFactory:
         else:
             config_store = cls._create_memory_store()
 
-        sender = BasePushNotificationSender(
-            httpx_client=httpx.AsyncClient(),
+        sender = AuthenticatedPushNotificationSender(
+            httpx_client=httpx.AsyncClient(timeout=cls._build_timeout()),
             config_store=config_store,
         )
         return config_store, sender
+
+    @staticmethod
+    def _build_timeout() -> httpx.Timeout:
+        """Builds the timeout policy for webhook deliveries.
+
+        httpx defaults every phase to 5 seconds, which is a poor fit for a
+        webhook: a receiver that authenticates the call and then does real work
+        before answering blows through it, and the delivery fails with
+        ``ReadTimeout`` even though the request was accepted. Waiting on the
+        response is therefore given its own, longer budget.
+
+        Connecting keeps the short budget. A host that cannot be reached should
+        fail immediately rather than hold the delivery open, since the first
+        delivery of a run is awaited in the request path.
+
+        Returns:
+            The timeout policy, with the connect phase pinned to five seconds
+            and the remaining phases taken from
+            ``PUSH_NOTIFICATION_TIMEOUT_SECONDS``.
+        """
+        return httpx.Timeout(
+            app_settings.push_notification_timeout_seconds,
+            connect=CONNECT_TIMEOUT_SECONDS,
+        )
 
     @staticmethod
     def _create_postgres_store(db_manager: DbManagerProtocol) -> PushNotificationConfigStore:

--- a/libs/aion-server/tests/tasks/test_push_notification_delivery.py
+++ b/libs/aion-server/tests/tasks/test_push_notification_delivery.py
@@ -25,11 +25,13 @@ outcome on the push channel.
 """
 
 import asyncio
+import httpx
 import pytest
 from a2a.server.agent_execution.agent_executor import AgentExecutor
 from a2a.server.agent_execution.context import RequestContext
 from a2a.server.context import ServerCallContext
 from a2a.server.events import EventQueue
+from a2a.server.tasks import InMemoryPushNotificationConfigStore
 from a2a.auth.user import User
 from a2a.types import (
     Message,
@@ -41,11 +43,13 @@ from a2a.types import (
     TaskStatus,
     TaskStatusUpdateEvent,
 )
+from a2a.types.a2a_pb2 import AuthenticationInfo, TaskPushNotificationConfig
 from unittest.mock import AsyncMock, Mock
 
 from aion.server.agent.execution import AionActiveTaskRegistry
 from aion.server.agent.execution.scope import clear_execution_scope, init_execution_scope
 from aion.server.core.app.handlers.terminal_task_projection import TerminalTaskProjection
+from aion.server.tasks.authenticated_push_sender import AuthenticatedPushNotificationSender
 from aion.server.tasks.stores.in_memory_task_store import InMemoryTaskStore
 from aion.server.tasks.terminal_push_sender import TerminalTaskPushSender
 
@@ -271,3 +275,87 @@ class TestPushSenderWiring:
 
         assert isinstance(active_task._push_sender, TerminalTaskPushSender)
         assert active_task._push_sender._inner is raw_push
+
+
+class TestAuthenticatedWebhookDelivery:
+    """The credentials a client declares on the config reach the HTTP call.
+
+    The tests above stub the transport, so they prove what the sender is
+    *asked* to deliver but not how it authenticates. This one runs the real
+    AuthenticatedPushNotificationSender underneath the same registry wiring,
+    with only httpx faked, and follows the config the whole way: stored by the
+    request handler on ``message/send``, read back at dispatch time, and turned
+    into request headers.
+    """
+
+    WEBHOOK_URL = "https://api-staging.aion.to/a2a/callbacks/jobs/job-1/push"
+    CREDENTIALS = "external-server-token"
+
+    @staticmethod
+    def _http_client() -> Mock:
+        """Returns an httpx client stand-in that accepts every delivery."""
+        client = Mock()
+        client.post = AsyncMock(
+            return_value=httpx.Response(
+                200, request=httpx.Request("POST", TestAuthenticatedWebhookDelivery.WEBHOOK_URL)
+            )
+        )
+        return client
+
+    async def _deliver(self, call_context: ServerCallContext, http_client: Mock) -> None:
+        """Runs one task to completion with the real push sender attached."""
+        config_store = InMemoryPushNotificationConfigStore()
+        await config_store.set_info(
+            TASK_ID,
+            TaskPushNotificationConfig(
+                task_id=TASK_ID,
+                url=self.WEBHOOK_URL,
+                authentication=AuthenticationInfo(
+                    scheme="Bearer", credentials=self.CREDENTIALS
+                ),
+            ),
+            call_context,
+        )
+        registry = AionActiveTaskRegistry(
+            agent_executor=_ScriptedExecutor([
+                Task(id=TASK_ID, context_id=CONTEXT_ID,
+                     status=TaskStatus(state=TaskState.TASK_STATE_SUBMITTED)),
+                _terminal_status(TaskState.TASK_STATE_COMPLETED),
+            ]),
+            task_store=InMemoryTaskStore(),
+            push_sender=AuthenticatedPushNotificationSender(
+                httpx_client=http_client, config_store=config_store
+            ),
+        )
+        active_task = await registry.get_or_create(
+            TASK_ID, call_context=call_context, context_id=CONTEXT_ID, create_task_if_missing=True,
+        )
+        request_context = RequestContext(
+            call_context=call_context, task_id=TASK_ID, context_id=CONTEXT_ID,
+        )
+        async for _ in active_task.subscribe(request=request_context):
+            pass
+        await asyncio.sleep(0.05)  # let the push-side consumer drain past the terminal event
+
+    @pytest.mark.anyio
+    async def test_declared_credentials_reach_the_webhook(self, execution_scope):
+        """Every delivery for an authenticated config carries the Authorization header."""
+        http_client = self._http_client()
+
+        await self._deliver(ServerCallContext(user=_NamedUser("alice")), http_client)
+
+        assert http_client.post.await_args_list, "no webhook call was made"
+        for call in http_client.post.await_args_list:
+            assert call.args[0] == self.WEBHOOK_URL
+            assert call.kwargs["headers"]["Authorization"] == f"Bearer {self.CREDENTIALS}"
+
+    @pytest.mark.anyio
+    async def test_terminal_task_is_the_authenticated_payload(self, execution_scope):
+        """The run still settles as a full Task — authentication does not alter the contract."""
+        http_client = self._http_client()
+
+        await self._deliver(ServerCallContext(user=_NamedUser("alice")), http_client)
+
+        final_payload = http_client.post.await_args_list[-1].kwargs["json"]
+        assert final_payload["task"]["id"] == TASK_ID
+        assert final_payload["task"]["status"]["state"] == "TASK_STATE_COMPLETED"

--- a/libs/aion-server/tests/unit/tasks/test_authenticated_push_sender.py
+++ b/libs/aion-server/tests/unit/tasks/test_authenticated_push_sender.py
@@ -1,0 +1,330 @@
+"""Tests for AuthenticatedPushNotificationSender.
+
+The sender owns the inbound half of the push contract that the SDK base class
+drops: a client that declares ``taskPushNotificationConfig.authentication``
+expects its callback endpoint to be called with those credentials. The base
+class emits only ``X-A2A-Notification-Token``, so an authenticated webhook
+rejects every delivery. These tests pin the header derivation and the failure
+handling around it.
+"""
+
+import httpx
+import logging
+import pytest
+from a2a.types import Task, TaskState, TaskStatus
+from a2a.types.a2a_pb2 import AuthenticationInfo, TaskPushNotificationConfig
+from unittest.mock import AsyncMock, Mock
+
+from aion.server.tasks.authenticated_push_sender import AuthenticatedPushNotificationSender
+
+TASK_ID = "task-1"
+CONTEXT_ID = "ctx-1"
+WEBHOOK_URL = "https://api-staging.aion.to/a2a/callbacks/jobs/job-1/push"
+CREDENTIALS = "secret-token-value"
+
+
+@pytest.fixture
+def anyio_backend():
+    """Run async tests on asyncio only."""
+    return "asyncio"
+
+
+def _config(
+        *,
+        token: str = "",
+        scheme: str | None = None,
+        credentials: str | None = None,
+) -> TaskPushNotificationConfig:
+    """Builds a stored push configuration.
+
+    Args:
+        token: Value for the SDK's own notification token, empty to omit it.
+        scheme: Authentication scheme to declare, None to omit authentication
+            entirely, empty string to declare credentials without a scheme.
+        credentials: Credential value to declare, None to omit authentication.
+
+    Returns:
+        The configuration as it would come back from the config store.
+    """
+    config = TaskPushNotificationConfig(task_id=TASK_ID, url=WEBHOOK_URL, token=token)
+    if credentials is not None:
+        config.authentication.CopyFrom(
+            AuthenticationInfo(scheme=scheme or "", credentials=credentials)
+        )
+    return config
+
+
+def _event() -> Task:
+    """Returns a terminal Task, the payload the push channel settles a run with."""
+    return Task(
+        id=TASK_ID,
+        context_id=CONTEXT_ID,
+        status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+    )
+
+
+def _client(status_code: int = 200, body: str = "") -> Mock:
+    """Returns an httpx client stand-in whose POST answers with the given status."""
+    response = httpx.Response(
+        status_code, request=httpx.Request("POST", WEBHOOK_URL), text=body
+    )
+    client = Mock()
+    client.post = AsyncMock(return_value=response)
+    return client
+
+
+def _store(config: TaskPushNotificationConfig) -> Mock:
+    """Returns a config store stand-in that dispatches to a single webhook."""
+    store = Mock()
+    store.get_info_for_dispatch = AsyncMock(return_value=[config])
+    return store
+
+
+def _sender(config: TaskPushNotificationConfig, client: Mock) -> AuthenticatedPushNotificationSender:
+    return AuthenticatedPushNotificationSender(
+        httpx_client=client, config_store=_store(config)
+    )
+
+
+def _sent_headers(client: Mock) -> dict[str, str] | None:
+    """Extracts the headers of the single POST the sender issued."""
+    client.post.assert_awaited_once()
+    return client.post.await_args.kwargs["headers"]
+
+
+class TestAuthorizationHeader:
+    """Declared credentials become a standard Authorization header."""
+
+    @pytest.mark.anyio
+    async def test_declared_scheme_and_credentials_are_sent(self):
+        """The scheme/credentials pair is sent verbatim as ``<scheme> <credentials>``."""
+        client = _client()
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        await sender.send_notification(TASK_ID, _event())
+
+        assert _sent_headers(client)["Authorization"] == f"Bearer {CREDENTIALS}"
+
+    @pytest.mark.anyio
+    async def test_non_bearer_scheme_is_preserved(self):
+        """A scheme other than Bearer is not rewritten."""
+        client = _client()
+        sender = _sender(_config(scheme="Basic", credentials="dXNlcjpwYXNz"), client)
+
+        await sender.send_notification(TASK_ID, _event())
+
+        assert _sent_headers(client)["Authorization"] == "Basic dXNlcjpwYXNz"
+
+    @pytest.mark.anyio
+    async def test_missing_scheme_defaults_to_bearer(self):
+        """Credentials without a named scheme are sent as a Bearer token.
+
+        Clients populate ``credentials`` and leave ``scheme`` empty often enough
+        that dropping the header would be the more surprising behaviour.
+        """
+        client = _client()
+        sender = _sender(_config(scheme="", credentials=CREDENTIALS), client)
+
+        await sender.send_notification(TASK_ID, _event())
+
+        assert _sent_headers(client)["Authorization"] == f"Bearer {CREDENTIALS}"
+
+    @pytest.mark.anyio
+    async def test_scheme_without_credentials_sends_nothing(self):
+        """A scheme with no credential value carries no authentication to send."""
+        client = _client()
+        sender = _sender(_config(scheme="Bearer", credentials=""), client)
+
+        await sender.send_notification(TASK_ID, _event())
+
+        assert _sent_headers(client) is None
+
+
+class TestBaseBehaviourIsPreserved:
+    """The notification token keeps working exactly as it did before."""
+
+    @pytest.mark.anyio
+    async def test_config_without_authentication_sends_no_authorization(self):
+        """An unauthenticated webhook is called the way the SDK base class called it."""
+        client = _client()
+        sender = _sender(_config(token="notify-token"), client)
+
+        await sender.send_notification(TASK_ID, _event())
+
+        headers = _sent_headers(client)
+        assert headers == {"X-A2A-Notification-Token": "notify-token"}
+
+    @pytest.mark.anyio
+    async def test_token_and_authentication_are_sent_together(self):
+        """The two channels are independent: a config setting both gets both headers."""
+        client = _client()
+        sender = _sender(
+            _config(token="notify-token", scheme="Bearer", credentials=CREDENTIALS),
+            client,
+        )
+
+        await sender.send_notification(TASK_ID, _event())
+
+        assert _sent_headers(client) == {
+            "X-A2A-Notification-Token": "notify-token",
+            "Authorization": f"Bearer {CREDENTIALS}",
+        }
+
+    @pytest.mark.anyio
+    async def test_bare_config_sends_no_headers(self):
+        """With neither token nor credentials the request carries no headers at all."""
+        client = _client()
+        sender = _sender(_config(), client)
+
+        await sender.send_notification(TASK_ID, _event())
+
+        assert _sent_headers(client) is None
+
+    @pytest.mark.anyio
+    async def test_event_is_posted_to_the_configured_url_as_a_stream_response(self):
+        """Authentication changes the headers only; URL and body stay as the base class sent them."""
+        client = _client()
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        await sender.send_notification(TASK_ID, _event())
+
+        url = client.post.await_args.args[0]
+        payload = client.post.await_args.kwargs["json"]
+        assert url == WEBHOOK_URL
+        assert payload["task"]["id"] == TASK_ID
+        assert payload["task"]["status"]["state"] == "TASK_STATE_COMPLETED"
+
+
+class TestFailureHandling:
+    """A rejected delivery is reported, not raised, and never leaks the credential."""
+
+    @pytest.mark.anyio
+    async def test_rejected_delivery_does_not_raise(self):
+        """A 401 from the webhook is swallowed, matching the base class contract.
+
+        Push dispatch runs in the background consumer with no caller to receive
+        an exception, so one failing webhook must not tear down the fan-out.
+        """
+        client = _client(status_code=401)
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        await sender.send_notification(TASK_ID, _event())
+
+        client.post.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_dispatch_reports_failure(self):
+        """The per-webhook dispatch reports False so the fan-out can log a summary."""
+        client = _client(status_code=500)
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        delivered = await sender._dispatch_notification(
+            _event(), _config(scheme="Bearer", credentials=CREDENTIALS), TASK_ID
+        )
+
+        assert delivered is False
+
+    @pytest.mark.anyio
+    async def test_successful_dispatch_reports_success(self):
+        """A 200 response is reported as delivered."""
+        config = _config(scheme="Bearer", credentials=CREDENTIALS)
+        client = _client()
+        sender = _sender(config, client)
+
+        delivered = await sender._dispatch_notification(_event(), config, TASK_ID)
+
+        assert delivered is True
+
+    @pytest.mark.anyio
+    async def test_credentials_are_never_logged(self, caplog):
+        """Failure logs identify the task and the URL, never the credential value."""
+        client = _client(status_code=401)
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        with caplog.at_level(logging.DEBUG):
+            await sender.send_notification(TASK_ID, _event())
+
+        assert CREDENTIALS not in caplog.text
+        assert WEBHOOK_URL in caplog.text
+
+    @pytest.mark.anyio
+    async def test_rejection_is_reported_by_status_not_stack_trace(self, caplog):
+        """A refused delivery reads as "the webhook said 401", not as a crash.
+
+        The status is the entire diagnosis for an authentication failure, and a
+        traceback through our own call frames only buries it.
+        """
+        client = _client(status_code=401)
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        with caplog.at_level(logging.DEBUG):
+            await sender.send_notification(TASK_ID, _event())
+
+        record = next(r for r in caplog.records if r.name.endswith("authenticated_push_sender"))
+        assert record.levelno == logging.WARNING
+        assert record.exc_info is None
+        assert "401" in record.getMessage()
+
+    @pytest.mark.anyio
+    async def test_rejection_reports_what_the_receiver_said(self, caplog):
+        """The receiver's own message distinguishes a gateway error from an app refusal."""
+        client = _client(status_code=503, body="upstream connect error")
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        with caplog.at_level(logging.DEBUG):
+            await sender.send_notification(TASK_ID, _event())
+
+        assert "upstream connect error" in caplog.text
+
+    @pytest.mark.anyio
+    async def test_long_rejection_body_is_truncated(self, caplog):
+        """A receiver answering with an HTML page must not flood the log."""
+        client = _client(status_code=503, body="x" * 5000)
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        with caplog.at_level(logging.DEBUG):
+            await sender.send_notification(TASK_ID, _event())
+
+        record = next(r for r in caplog.records if r.name.endswith("authenticated_push_sender"))
+        assert len(record.getMessage()) < 600
+        assert "…" in record.getMessage()
+
+    @pytest.mark.anyio
+    async def test_empty_rejection_body_is_labelled(self, caplog):
+        """A bare status code still reads as a complete sentence."""
+        client = _client(status_code=502)
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        with caplog.at_level(logging.DEBUG):
+            await sender.send_notification(TASK_ID, _event())
+
+        assert "<empty body>" in caplog.text
+
+    @pytest.mark.anyio
+    async def test_timeout_is_reported_as_a_condition(self, caplog):
+        """A slow receiver is an operational condition with a documented knob."""
+        client = Mock()
+        client.post = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        with caplog.at_level(logging.DEBUG):
+            await sender.send_notification(TASK_ID, _event())
+
+        record = next(r for r in caplog.records if r.name.endswith("authenticated_push_sender"))
+        assert record.levelno == logging.WARNING
+        assert record.exc_info is None
+        assert "PUSH_NOTIFICATION_TIMEOUT_SECONDS" in record.getMessage()
+
+    @pytest.mark.anyio
+    async def test_unexpected_failure_keeps_its_traceback(self, caplog):
+        """Anything not recognised as an operational condition still logs in full."""
+        client = Mock()
+        client.post = AsyncMock(side_effect=RuntimeError("boom"))
+        sender = _sender(_config(scheme="Bearer", credentials=CREDENTIALS), client)
+
+        with caplog.at_level(logging.DEBUG):
+            await sender.send_notification(TASK_ID, _event())
+
+        record = next(r for r in caplog.records if r.name.endswith("authenticated_push_sender"))
+        assert record.levelno == logging.ERROR
+        assert record.exc_info is not None

--- a/libs/aion-server/tests/unit/tasks/test_push_notification_factory.py
+++ b/libs/aion-server/tests/unit/tasks/test_push_notification_factory.py
@@ -1,0 +1,94 @@
+"""Tests for PushNotificationFactory.
+
+The factory decides two things the push channel depends on and nothing else
+asserts: which sender the server dispatches through — the SDK base class sends
+webhook calls anonymously — and how long a delivery may wait for the receiver,
+which httpx otherwise defaults to five seconds for.
+"""
+
+import pytest
+from a2a.server.tasks import InMemoryPushNotificationConfigStore
+from unittest.mock import Mock, patch
+
+from aion.server.tasks.authenticated_push_sender import AuthenticatedPushNotificationSender
+from aion.server.tasks.push_notifications import PushNotificationFactory
+
+STORE_PATH = (
+    "a2a.server.tasks.database_push_notification_config_store."
+    "DatabasePushNotificationConfigStore"
+)
+
+
+@pytest.fixture
+def db_manager() -> Mock:
+    """An initialized db manager stand-in exposing a chainable engine."""
+    manager = Mock()
+    manager.is_initialized = True
+    manager.get_engine.return_value.execution_options.return_value = Mock()
+    return manager
+
+
+class TestSenderSelection:
+    """The server must dispatch through the sender that honours declared credentials."""
+
+    def test_sender_authenticates_deliveries(self):
+        """A config declaring authentication is useless unless this sender is wired in."""
+        config_store, sender = PushNotificationFactory.create()
+
+        assert isinstance(sender, AuthenticatedPushNotificationSender)
+        assert isinstance(config_store, InMemoryPushNotificationConfigStore)
+
+    def test_sender_reads_from_the_store_it_returns(self):
+        """Dispatch resolves configs through the same store the handler writes to."""
+        config_store, sender = PushNotificationFactory.create()
+
+        assert sender._config_store is config_store
+
+    def test_uninitialized_db_falls_back_to_memory(self):
+        """A db manager that never came up must not take the postgres path."""
+        manager = Mock()
+        manager.is_initialized = False
+
+        config_store, _ = PushNotificationFactory.create(manager)
+
+        assert isinstance(config_store, InMemoryPushNotificationConfigStore)
+
+    def test_initialized_db_takes_the_postgres_path(self, db_manager):
+        """With a live database the configs must outlive the process."""
+        with patch(STORE_PATH) as store_cls:
+            config_store, _ = PushNotificationFactory.create(db_manager)
+
+        assert config_store is store_cls.return_value
+
+
+class TestDeliveryTimeout:
+    """httpx defaults every phase to 5s, too short for a webhook that works before answering."""
+
+    def test_read_timeout_comes_from_settings(self, monkeypatch):
+        """The configured budget is what waiting on the webhook response gets."""
+        monkeypatch.setattr(
+            "aion.server.tasks.push_notifications.app_settings.push_notification_timeout_seconds",
+            45.0,
+        )
+
+        _, sender = PushNotificationFactory.create()
+
+        assert sender._client.timeout.read == 45.0
+        assert sender._client.timeout.write == 45.0
+
+    def test_connect_stays_short(self, monkeypatch):
+        """An unreachable host must fail fast: the first delivery blocks the request path."""
+        monkeypatch.setattr(
+            "aion.server.tasks.push_notifications.app_settings.push_notification_timeout_seconds",
+            45.0,
+        )
+
+        _, sender = PushNotificationFactory.create()
+
+        assert sender._client.timeout.connect == 5.0
+
+    def test_default_exceeds_the_httpx_default(self):
+        """The whole point of the setting is to not ship httpx's 5 seconds."""
+        _, sender = PushNotificationFactory.create()
+
+        assert sender._client.timeout.read > 5.0

--- a/libs/aion-server/tests/unit/test_sdk_override_parity.py
+++ b/libs/aion-server/tests/unit/test_sdk_override_parity.py
@@ -26,6 +26,7 @@ from a2a.server.agent_execution.active_task_registry import ActiveTaskRegistry
 from a2a.server.request_handlers import DefaultRequestHandlerV2
 from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
 from a2a.server.tasks import TaskManager, TaskStore
+from a2a.server.tasks.base_push_notification_sender import BasePushNotificationSender
 from a2a.server.tasks.push_notification_sender import PushNotificationSender
 from a2a.types import Message, Role
 from unittest.mock import AsyncMock, Mock, patch
@@ -36,6 +37,7 @@ from aion.server.agent.execution.request_context_builder import AionRequestConte
 from aion.server.agent.execution.request_executor import AionAgentRequestExecutor
 from aion.server.core.app.handlers.jsonrpc_dispatcher import AionJsonRpcDispatcher
 from aion.server.core.app.handlers.request_handler import AionRequestHandler
+from aion.server.tasks.authenticated_push_sender import AuthenticatedPushNotificationSender
 from aion.server.tasks.stores.in_memory_task_store import InMemoryTaskStore
 from aion.server.tasks.stores.postgres_task_store import PostgresTaskStore
 from aion.server.tasks.task_manager import AionTaskManager
@@ -58,6 +60,11 @@ OVERRIDES = [
     (AionAgentRequestExecutor, AgentExecutor, "execute"),
     (AionAgentRequestExecutor, AgentExecutor, "cancel"),
     (TerminalTaskPushSender, PushNotificationSender, "send_notification"),
+    (
+        AuthenticatedPushNotificationSender,
+        BasePushNotificationSender,
+        "_dispatch_notification",
+    ),
     (InMemoryTaskStore, TaskStore, "save"),
     (InMemoryTaskStore, TaskStore, "get"),
     (InMemoryTaskStore, TaskStore, "delete"),


### PR DESCRIPTION
…th errors

- add AuthenticatedPushNotificationSender: sends PushNotificationConfig.authentication as an Authorization header; configurable PUSH_NOTIFICATION_TIMEOUT_SECONDS (connect stays 5s)
- point sync auth at /auth/tokens (was /auth/token) and carry status_code on AionAuthenticationError
- latch _auth_failed only on 401; 404/5xx stay retryable
- rename logstash "tags" field to "_tags"
- rewrite AGENTS.md: package layering and per-package descriptions